### PR TITLE
Add onTab property, if onTab passed in, default behavior will be exec…

### DIFF
--- a/js/src/components/Editor/index.js
+++ b/js/src/components/Editor/index.js
@@ -51,6 +51,7 @@ export default class WysiwygEditor extends Component {
     onChange: PropTypes.func,
     onEditorStateChange: PropTypes.func,
     onContentStateChange: PropTypes.func,
+    onTab: PropTypes.func,
     // initialContentState is deprecated
     initialContentState: PropTypes.object,
     defaultContentState: PropTypes.object,
@@ -165,11 +166,24 @@ export default class WysiwygEditor extends Component {
   }
 
   onTab: Function = (event): boolean => {
-    const editorState = changeDepth(this.state.editorState, event.shiftKey ? -1 : 1, 4);
-    if (editorState) {
-      this.onChange(editorState);
-      event.preventDefault();
+
+    const { onTab } = this.props;
+
+    let executeDefaultTabBehavior = true;
+    if (onTab) {
+      let result = onTab();
+      executeDefaultTabBehavior = (result !== true)
     }
+
+    if (executeDefaultTabBehavior) {
+      const editorState = changeDepth(this.state.editorState, event.shiftKey ? -1 : 1, 4);
+      if (editorState) {
+        this.onChange(editorState);
+        event.preventDefault();
+      }
+    }
+
+
   };
 
   onUpDownArrow: Function = (event): boolean => {

--- a/js/src/components/Editor/index.js
+++ b/js/src/components/Editor/index.js
@@ -171,7 +171,7 @@ export default class WysiwygEditor extends Component {
 
     let executeDefaultTabBehavior = true;
     if (onTab) {
-      let result = onTab();
+      let result = onTab(event);
       executeDefaultTabBehavior = (result !== true)
     }
 


### PR DESCRIPTION
…uted only if the onTab property function returns non-true value. Fixes #150 

Was unable to add unit test. Using `mount` to fully mount the component failed when trying to initialize the modal in `componentDidMount`. I commented this out locally to try and simulate the tab keypress but was unable to get the event to fire. I ended up linking the package and testing manually.