### PR TITLE
Ability to specify custom block renderer

### DIFF
--- a/js/src/components/Editor/index.js
+++ b/js/src/components/Editor/index.js
@@ -83,6 +83,7 @@ export default class WysiwygEditor extends Component {
     ariaDescribedBy: PropTypes.string,
     ariaExpanded: PropTypes.string,
     ariaHasPopup: PropTypes.string,
+    customBlockRenderFunc: PropTypes.func,
   };
 
   static defaultProps = {
@@ -104,7 +105,7 @@ export default class WysiwygEditor extends Component {
     this.wrapperId = `rdw-wrapper${Math.floor(Math.random() * 10000)}`;
     this.modalHandler = new ModalHandler();
     this.focusHandler = new FocusHandler();
-    this.blockRendererFn = getBlockRenderFunc({ isReadOnly: this.isReadOnly });
+    this.blockRendererFn = getBlockRenderFunc({ isReadOnly: this.isReadOnly }, props.customBlockRenderFunc);
   }
 
   componentWillMount(): void {

--- a/js/src/renderer/index.js
+++ b/js/src/renderer/index.js
@@ -2,8 +2,12 @@ import { Entity, ContentBlock } from 'draft-js';
 import Embedded from './Embedded';
 import getImageComponent from './Image';
 
-const getBlockRenderFunc = (config) => {
+const getBlockRenderFunc = (config, customBlockRendererFunc) => {
   return (block) => {
+    if (typeof customBlockRendererFunc === 'function') {
+      const renderedComponent = customBlockRendererFunc(block, config);
+      if (renderedComponent) return renderedComponent;
+    }
     if (block.getType() === 'atomic') {
       const entity = Entity.get(block.getEntityAt(0));
       if (entity && entity.type === 'IMAGE') {


### PR DESCRIPTION
This PR allows the ability to render other entities than images or embeds.
We use it internally to render Tweets and Instagram Posts.