### PR TITLE
allow passthrough of ...props to draft-js editor

### DIFF
--- a/js/src/components/Editor/index.js
+++ b/js/src/components/Editor/index.js
@@ -360,6 +360,7 @@ export default class WysiwygEditor extends Component {
       ariaDescribedBy,
       ariaExpanded,
       ariaHasPopup,
+      ...props,
     } = this.props;
 
     const controlProps = {
@@ -435,6 +436,7 @@ export default class WysiwygEditor extends Component {
             ariaHasPopup={ariaHasPopup}
             ariaReadonly={readOnly}
             placeholder={placeholder}
+            {...props}
           />
         </div>
       </div>


### PR DESCRIPTION
Per issue #189 

We could pass through this specific prop if you're worried about ...props, but this seems like it could prevent future such PRs.