### PR TITLE
Passing editor state customBlockRenderer

### DIFF
--- a/js/src/renderer/index.js
+++ b/js/src/renderer/index.js
@@ -4,7 +4,7 @@ import getImageComponent from './Image';
 const getBlockRenderFunc = (config, customBlockRenderer, getEditorState) => {
   return (block) => {
     if (typeof customBlockRenderer === 'function') {
-      const renderedComponent = customBlockRenderer(block, config);
+      const renderedComponent = customBlockRenderer(block, config, getEditorState);
       if (renderedComponent) return renderedComponent;
     }
     if (block.getType() === 'atomic') {


### PR DESCRIPTION
In a recent update the editor state is passed to the block renderer, however it is not passed to the user defined block renderer. This is solved by this PR.

This PR is based on master as develop didn't include the functionality.

