### PR TITLE
feat: adding toolbarDisable prop for hiding toolbar

### DIFF
--- a/js/src/components/Editor/__test__/editorTest.js
+++ b/js/src/components/Editor/__test__/editorTest.js
@@ -15,4 +15,14 @@ describe('Editor menu test suite', () => {
     assert.isDefined(editor.state().editorState);
     assert.isDefined(editor.state().editorFocused);
   });
+
+  it('should have toolbarDisable as false by default', () => {
+    const editor = shallow(<Editor />);
+    expect(editor.find('.rdw-editor-toolbar')).to.have.length(1);
+  });
+
+  it('should not have toolbar if toolbarDisable is set to true', () => {
+    const editor = shallow(<Editor toolbarDisable />);
+    expect(editor.find('.rdw-editor-toolbar')).to.have.length(0);
+  });
 });

--- a/js/src/components/Editor/index.js
+++ b/js/src/components/Editor/index.js
@@ -52,6 +52,7 @@ export default class WysiwygEditor extends Component {
     toolbar: PropTypes.object,
     toolbarCustomButtons: PropTypes.array,
     toolbarClassName: PropTypes.string,
+    toolbarDisable: PropTypes.bool,
     editorClassName: PropTypes.string,
     wrapperClassName: PropTypes.string,
     toolbarStyle: PropTypes.object,
@@ -79,6 +80,7 @@ export default class WysiwygEditor extends Component {
 
   static defaultProps = {
     toolbarOnFocus: false,
+    toolbarDisable: false,
     stripPastedStyles: false,
   }
 
@@ -363,6 +365,7 @@ export default class WysiwygEditor extends Component {
       toolbarCustomButtons,
       toolbarOnFocus,
       toolbarClassName,
+      toolbarDisable,
       editorClassName,
       wrapperClassName,
       toolbarStyle,
@@ -388,7 +391,9 @@ export default class WysiwygEditor extends Component {
         onBlur={this.onWrapperBlur}
         aria-label="rdw-wrapper"
       >
-        {(editorFocused || this.focusHandler.isInputFocused() || !toolbarOnFocus) &&
+        {
+          !toolbarDisable &&
+          (editorFocused || this.focusHandler.isInputFocused() || !toolbarOnFocus) &&
           <div
             className={classNames('rdw-editor-toolbar', toolbarClassName)}
             style={toolbarStyle}


### PR DESCRIPTION
this is to add ```toolbarDisable``` for hiding the toolbar. Fixes https://github.com/jpuri/react-draft-wysiwyg/issues/232