### PR TITLE
Fixed web webpack.dev.config.js when using npm start

### DIFF
--- a/config/webpack.dev.config.js
+++ b/config/webpack.dev.config.js
@@ -53,7 +53,7 @@ const devConfigs = {
 }
 
 if (process.env.BABEL_ENV === 'TEST') {
-  devConfigs.revolve = {
+  devConfigs.resolve = {
     alias: {
       'draftjs-to-html': path.join(__dirname, '../../draftjs-to-html', 'js'),
       'draftjs-to-markdown': path.join(__dirname, '../../draftjs-to-markdown', 'js'),

--- a/config/webpack.dev.config.js
+++ b/config/webpack.dev.config.js
@@ -5,7 +5,7 @@ const precss = require('precss');
 const HtmlWebpackPlugin = require('html-webpack-plugin');
 const webpack = require('webpack');
 
-module.exports = {
+const devConfigs = {
   devtool: 'source-map',
   entry: [
     'webpack-hot-middleware/client',
@@ -49,12 +49,17 @@ module.exports = {
         postcss: [autoprefixer, precss],
       }
     })
-  ],
-  resolve: {
+  ]
+}
+
+if (process.env.BABEL_ENV === 'TEST') {
+  devConfigs.revolve = {
     alias: {
       'draftjs-to-html': path.join(__dirname, '../../draftjs-to-html', 'js'),
       'draftjs-to-markdown': path.join(__dirname, '../../draftjs-to-markdown', 'js'),
     },
     extensions: ['.js', '.json'],
-  },
-};
+  };
+}
+
+module.exports = devConfigs;


### PR DESCRIPTION
I was not able to use `npm start` to run the playground editor while working on issue #241

This fixed the issue but the tests seemed to be broken from the ReactIntl addition, so I could not make sure they worked.

Tested on Linux 4.10.1-1-ARCH.