### PR TITLE
Prevent crash when drag and dropping image from another browser.

### DIFF
--- a/src/controls/Image/Component/index.js
+++ b/src/controls/Image/Component/index.js
@@ -59,7 +59,33 @@ class LayoutComponent extends Component {
     this.setState({
       dragEnter: false,
     });
-    this.uploadImage(event.dataTransfer.files[0]);
+
+    // Check if property name is files or items
+    let data = event.dataTransfer.items;
+    let dataIsItems = true;
+
+    // IE uses 'files' instead of 'items'
+    if (!data) {
+      data = event.dataTransfer.files;
+      dataIsItems = false;
+    }
+
+    for (let i = 0; i < data.length; i += 1) {
+      if (data[i].kind === 'string' && data[i].type.match('^text/plain')) {
+        // This item is the target node
+        continue;
+      } else if (data[i].kind === 'string' && data[i].type.match('^text/html')) {
+        // Drag data item is HTML
+        continue;
+      } else if (data[i].kind === 'string' && data[i].type.match('^text/uri-list')) {
+        // Drag data item is URI
+        continue;
+      } else if ((!dataIsItems || data[i].kind === 'file') && data[i].type.match('^image/')) {
+        // Drag data item is an image file
+        const file = dataIsItems ? data[i].getAsFile() : data[i];
+        this.uploadImage(file);
+      }
+    }
   };
 
   showImageUploadOption: Function = (): void => {


### PR DESCRIPTION
Prevent crash when drag and dropping image from another browser into the image uploader.

For #247