### PR TITLE
Add .editorconfig for IDE and fix 'linebreak-style' rule for eslint

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,6 @@
+root = true
+
+[*]
+end_of_line = crlf
+indent_style = space
+indent_size = 2

--- a/.eslintrc
+++ b/.eslintrc
@@ -11,6 +11,10 @@
     "react/forbid-prop-types": 0,
     "react/no-array-index-key": 0,
     "react/require-default-props": 0,
-    "import/no-unresolved": 2
+    "import/no-unresolved": 2,
+    "linebreak-style": [
+      "error",
+      "windows"
+    ]
   }
 }


### PR DESCRIPTION
I add [.editorconfig](http://editorconfig.org/) for fix lint error in IDE. The rules:
```
end_of_line = crlf
indent_style = space
indent_size = 2
```
Also add [rule](http://eslint.org/docs/rules/linebreak-style) `linebreak-style` in `.eslintrc`:
```
"linebreak-style": [
      "error",
      "windows"
    ]
```
because all lines endings `\r\n`.