### PR TITLE
added french translation of 'Target blank'

### DIFF
--- a/js/src/i18n/en.js
+++ b/js/src/i18n/en.js
@@ -34,5 +34,5 @@ module.exports = {
   // Link
   'components.controls.link.linkTitle': 'Link Title',
   'components.controls.link.linkTarget': 'Link Target',
-  'components.controls.link.linkTargetOption': 'Target blank',
+  'components.controls.link.linkTargetOption': 'Open link in new window',
 };

--- a/js/src/i18n/fr.js
+++ b/js/src/i18n/fr.js
@@ -34,5 +34,5 @@ module.exports = {
   //Link
   'components.controls.link.linkTitle': 'Titre du lien',
   'components.controls.link.linkTarget': 'Cible du lien',
-  'components.controls.link.linkTargetOption': 'Target blank',
+  'components.controls.link.linkTargetOption': 'Ouvrir le lien dans une nouvelle fenêtre',
 }


### PR DESCRIPTION
I think it makes much more sense to translate "Target blank" with its actual meaning (as far as I understand), which is to open the link in a new window. So I translated "open link in a new window".
I would suggest to change "Target blank" with "Open link in a new window" in English too... I would happily add this to the PR if you agree.
In case I didn't understand what the "target blank" checkbox is for, please explain to me :)
Thanks a lot for this project, and thanks for all your hard work !