### PR TITLE
Accessing PropTypes via the main React package is deprecated.

### DIFF
--- a/docs/src/components/App/index.js
+++ b/docs/src/components/App/index.js
@@ -1,13 +1,13 @@
 /* @flow */
 
-import React, { Component, PropTypes } from 'react';
+import React, { Component } from 'react';
+import PropTypes from 'prop-types';
 import Menu from '../Menu';
 import github from '../../../images/github.png';
 import paperPen from '../../../images/paper_pen.svg';
 import styles from './styles.css'; // eslint-disable-line no-unused-vars
 
 export default class App extends Component {
-
   static propTypes = {
     children: PropTypes.object.isRequired,
     location: PropTypes.object,
@@ -23,11 +23,17 @@ export default class App extends Component {
             </a>
             <span className="header-text">
               <span className="header-title">
-                <a href="https://jpuri.github.io/react-draft-wysiwyg/" className="header-label">React Draft Wysiwyg</a>
+                <a href="https://jpuri.github.io/react-draft-wysiwyg/" className="header-label">
+                  React Draft Wysiwyg
+                </a>
               </span>
               <span className="header-subtitle">A Wysiwyg Built on ReactJS and DraftJS</span>
             </span>
-            <a target="_blank" href="https://github.com/jpuri/react-draft-wysiwyg" rel="noopener noreferrer">
+            <a
+              target="_blank"
+              href="https://github.com/jpuri/react-draft-wysiwyg"
+              rel="noopener noreferrer"
+            >
               <img className="github" src={github} alt="Fork me on GitHub" />
             </a>
           </span>
@@ -37,7 +43,16 @@ export default class App extends Component {
           {this.props.children}
         </div>
         <span className="footer">
-          Made with ❤ by <a target="_blank" href="https://twitter.com/jyopur" className="author-link" rel="noopener noreferrer"> Jyoti</a>
+          Made with ❤ by
+          {' '}
+          <a
+            target="_blank"
+            href="https://twitter.com/jyopur"
+            className="author-link"
+            rel="noopener noreferrer"
+          >
+            {' '}Jyoti
+          </a>
         </span>
       </div>
     );

--- a/docs/src/components/Demo/ColorPic/index.js
+++ b/docs/src/components/Demo/ColorPic/index.js
@@ -1,6 +1,7 @@
 /* @flow */
 
-import React, { Component, PropTypes } from 'react';
+import React, { Component } from 'react';
+import PropTypes from 'prop-types';
 import classNames from 'classnames';
 import { BlockPicker } from 'react-color';
 
@@ -8,7 +9,6 @@ import icon from '../../../icons/palette.svg';
 import styles from './styles.css'; // eslint-disable-line no-unused-vars
 
 class ColorPic extends Component {
-
   static propTypes = {
     expanded: PropTypes.bool,
     onExpandEvent: PropTypes.func,
@@ -23,15 +23,12 @@ class ColorPic extends Component {
   onChange = (color) => {
     const { onChange } = this.props;
     onChange('color', color.hex);
-  }
+  };
 
   renderModal = () => {
     const { color } = this.props.currentState;
     return (
-      <div
-        className="demo-color-modal"
-        onClick={this.stopPropagation}
-      >
+      <div className="demo-color-modal" onClick={this.stopPropagation}>
         <BlockPicker value={color} onChange={this.onChange} />
       </div>
     );
@@ -46,15 +43,8 @@ class ColorPic extends Component {
         aria-expanded={expanded}
         aria-label="rdw-color-picker"
       >
-        <div
-          onClick={onExpandEvent}
-          className="demo-icon-wrapper"
-        >
-          <img
-            className="demo-icon"
-            src={icon}
-            alt=""
-          />
+        <div onClick={onExpandEvent} className="demo-icon-wrapper">
+          <img className="demo-icon" src={icon} alt="" />
         </div>
         {expanded ? this.renderModal() : undefined}
       </div>

--- a/docs/src/components/Menu/index.js
+++ b/docs/src/components/Menu/index.js
@@ -1,12 +1,12 @@
 /* @flow */
 
-import React, { Component, PropTypes } from 'react';
+import React, { Component } from 'react';
+import PropTypes from 'prop-types';
 import { Link } from 'react-router';
 import classNames from 'classnames';
 import styles from './styles.css'; // eslint-disable-line no-unused-vars
 
 export default class Menu extends Component {
-
   static propTypes = {
     pathname: PropTypes.string,
   };
@@ -26,16 +26,28 @@ export default class Menu extends Component {
     const { pathname } = this.props;
     return (
       <div className="menu-root">
-        <Link to={'/'} className={classNames('menu-option', { 'menu-option-active': pathname === '/' })}>
+        <Link
+          to={'/'}
+          className={classNames('menu-option', { 'menu-option-active': pathname === '/' })}
+        >
           Home
         </Link>
-        <Link to={'/demo'} className={classNames('menu-option', { 'menu-option-active': pathname === '/demo' })}>
+        <Link
+          to={'/demo'}
+          className={classNames('menu-option', { 'menu-option-active': pathname === '/demo' })}
+        >
           Demo
         </Link>
-        <Link to={'/docs'} className={classNames('menu-option', { 'menu-option-active': pathname === '/docs' })}>
+        <Link
+          to={'/docs'}
+          className={classNames('menu-option', { 'menu-option-active': pathname === '/docs' })}
+        >
           Docs
         </Link>
-        <Link to={'/author'} className={classNames('menu-option', { 'menu-option-active': pathname === '/author' })}>
+        <Link
+          to={'/author'}
+          className={classNames('menu-option', { 'menu-option-active': pathname === '/author' })}
+        >
           Author
         </Link>
       </div>

--- a/js/src/Decorators/Link/index.js
+++ b/js/src/Decorators/Link/index.js
@@ -1,23 +1,17 @@
-import React, { PropTypes, Component } from 'react';
+import React, { Component } from 'react';
+import PropTypes from 'prop-types';
 import { Entity } from 'draft-js';
 import styles from './styles.css'; // eslint-disable-line no-unused-vars
 import openlink from '../../../../images/openlink.svg';
 
 function findLinkEntities(contentBlock, callback, contentState) {
-  contentBlock.findEntityRanges(
-    (character) => {
-      const entityKey = character.getEntity();
-      return (
-        entityKey !== null &&
-        contentState.getEntity(entityKey).getType() === 'LINK'
-      );
-    },
-    callback
-  );
+  contentBlock.findEntityRanges((character) => {
+    const entityKey = character.getEntity();
+    return entityKey !== null && contentState.getEntity(entityKey).getType() === 'LINK';
+  }, callback);
 }
 
 class Link extends Component {
-
   static propTypes = {
     entityKey: PropTypes.string.isRequired,
     children: PropTypes.array,
@@ -53,15 +47,14 @@ class Link extends Component {
         onMouseLeave={this.toggleShowPopOver}
       >
         <a href={url} target={targetOption}>{children}</a>
-        {showPopOver ?
-          <img
+        {showPopOver
+          ? <img
             src={openlink}
             alt=""
             onClick={this.openLink}
             className="rdw-link-decorator-icon"
           />
-          : undefined
-        }
+          : undefined}
       </span>
     );
   }

--- a/js/src/Renderer/Image/index.js
+++ b/js/src/Renderer/Image/index.js
@@ -1,121 +1,98 @@
-import React, { PropTypes, Component } from 'react';
+import React, { Component } from 'react';
+import PropTypes from 'prop-types';
 import { Entity, EditorState } from 'draft-js';
 import classNames from 'classnames';
 import Option from '../../components/Option';
 import styles from './styles.css'; // eslint-disable-line no-unused-vars
 
-const getImageComponent = (config) => {
+const getImageComponent = config => class Image extends Component {
+  static propTypes: Object = {
+    block: PropTypes.object,
+    contentState: PropTypes.object,
+  };
 
-  return class Image extends Component {
+  state: Object = {
+    hovered: false,
+  };
 
-    static propTypes: Object = {
-      block: PropTypes.object,
-      contentState: PropTypes.object,
-    };
+  setEntityAlignmentLeft: Function = (): void => {
+    this.setEntityAlignment('left');
+  };
 
-    state: Object = {
-      hovered: false,
-    };
+  setEntityAlignmentRight: Function = (): void => {
+    this.setEntityAlignment('right');
+  };
 
-    setEntityAlignmentLeft: Function = (): void => {
-      this.setEntityAlignment('left');
-    };
+  setEntityAlignmentCenter: Function = (): void => {
+    this.setEntityAlignment('none');
+  };
 
-    setEntityAlignmentRight: Function = (): void => {
-      this.setEntityAlignment('right');
-    };
+  setEntityAlignment: Function = (alignment): void => {
+    const { block, contentState } = this.props;
+    const entityKey = block.getEntityAt(0);
+    contentState.mergeEntityData(entityKey, { alignment });
+    config.onChange(EditorState.push(config.getEditorState(), contentState, 'change-block-data'));
+    this.setState({
+      dummy: true,
+    });
+  };
 
-    setEntityAlignmentCenter: Function = (): void => {
-      this.setEntityAlignment('none');
-    };
+  toggleHovered: Function = (): void => {
+    const hovered = !this.state.hovered;
+    this.setState({
+      hovered,
+    });
+  };
 
-    setEntityAlignment: Function = (alignment): void => {
-      const { block, contentState } = this.props;
-      const entityKey = block.getEntityAt(0);
-      contentState.mergeEntityData(
-        entityKey,
-        { alignment }
-      );
-      config.onChange(EditorState.push(config.getEditorState(), contentState, 'change-block-data'))
-      this.setState({
-        dummy: true,
-      });
-    };
-
-    toggleHovered: Function = (): void => {
-      const hovered = !this.state.hovered;
-      this.setState({
-        hovered,
-      });
-    };
-
-    renderAlignmentOptions(): Object {
-      return (
-        <div
-          className="rdw-image-alignment-options-popup"
-        >
-          <Option
-            onClick={this.setEntityAlignmentLeft}
-            className="rdw-image-alignment-option"
-          >
+  renderAlignmentOptions(): Object {
+    return (
+      <div className="rdw-image-alignment-options-popup">
+        <Option onClick={this.setEntityAlignmentLeft} className="rdw-image-alignment-option">
             L
           </Option>
-          <Option
-            onClick={this.setEntityAlignmentCenter}
-            className="rdw-image-alignment-option"
-          >
+        <Option onClick={this.setEntityAlignmentCenter} className="rdw-image-alignment-option">
             C
           </Option>
-          <Option
-            onClick={this.setEntityAlignmentRight}
-            className="rdw-image-alignment-option"
-          >
+        <Option onClick={this.setEntityAlignmentRight} className="rdw-image-alignment-option">
             R
           </Option>
-        </div>
-      );
-    }
-
-    render(): Object {
-      const { block, contentState } = this.props;
-      const { hovered } = this.state;
-      const { isReadOnly, isImageAlignmentEnabled } = config;
-      const entity = contentState.getEntity(block.getEntityAt(0));
-      const { src, alignment, height, width } = entity.getData();
-
-      return (
-        <span
-          onMouseEnter={this.toggleHovered}
-          onMouseLeave={this.toggleHovered}
-          className={classNames(
-            'rdw-image-alignment',
-            {
-              'rdw-image-left': alignment === 'left',
-              'rdw-image-right': alignment === 'right',
-              'rdw-image-center': !alignment || alignment === 'none',
-            }
-          )}
-        >
-          <span className="rdw-image-imagewrapper">
-            <img
-              src={src}
-              alt=""
-              style={{
-                height,
-                width,
-              }}
-            />
-            {
-              !isReadOnly() && hovered && isImageAlignmentEnabled() ?
-                this.renderAlignmentOptions()
-                :
-                undefined
-            }
-          </span>
-        </span>
-      );
-    }
+      </div>
+    );
   }
-}
+
+  render(): Object {
+    const { block, contentState } = this.props;
+    const { hovered } = this.state;
+    const { isReadOnly, isImageAlignmentEnabled } = config;
+    const entity = contentState.getEntity(block.getEntityAt(0));
+    const { src, alignment, height, width } = entity.getData();
+
+    return (
+      <span
+        onMouseEnter={this.toggleHovered}
+        onMouseLeave={this.toggleHovered}
+        className={classNames('rdw-image-alignment', {
+          'rdw-image-left': alignment === 'left',
+          'rdw-image-right': alignment === 'right',
+          'rdw-image-center': !alignment || alignment === 'none',
+        })}
+      >
+        <span className="rdw-image-imagewrapper">
+          <img
+            src={src}
+            alt=""
+            style={{
+              height,
+              width,
+            }}
+          />
+          {!isReadOnly() && hovered && isImageAlignmentEnabled()
+              ? this.renderAlignmentOptions()
+              : undefined}
+        </span>
+      </span>
+    );
+  }
+  };
 
 export default getImageComponent;

--- a/js/src/components/Controls/BlockType/Component/index.js
+++ b/js/src/components/Controls/BlockType/Component/index.js
@@ -1,6 +1,7 @@
 /* @flow */
 
-import React, { Component, PropTypes } from 'react';
+import React, { Component } from 'react';
+import PropTypes from 'prop-types';
 import classNames from 'classnames';
 
 import Option from '../../../Option';
@@ -8,7 +9,6 @@ import { Dropdown, DropdownOption } from '../../../Dropdown';
 import styles from './styles.css'; // eslint-disable-line no-unused-vars
 
 class LayoutComponent extends Component {
-
   static propTypes = {
     expanded: PropTypes.bool,
     onExpandEvent: PropTypes.func,
@@ -21,22 +21,27 @@ class LayoutComponent extends Component {
   };
 
   blocksTypes: Array<Object> = [
-    { label: 'Normal', displayName: this.props.translations['components.controls.blocktype.normal'] },
+    {
+      label: 'Normal',
+      displayName: this.props.translations['components.controls.blocktype.normal'],
+    },
     { label: 'H1', displayName: this.props.translations['components.controls.blocktype.h1'] },
     { label: 'H2', displayName: this.props.translations['components.controls.blocktype.h2'] },
     { label: 'H3', displayName: this.props.translations['components.controls.blocktype.h3'] },
     { label: 'H4', displayName: this.props.translations['components.controls.blocktype.h4'] },
     { label: 'H5', displayName: this.props.translations['components.controls.blocktype.h5'] },
     { label: 'H6', displayName: this.props.translations['components.controls.blocktype.h6'] },
-    { label: 'Blockquote', displayName: this.props.translations['components.controls.blocktype.blockquote'] },
+    {
+      label: 'Blockquote',
+      displayName: this.props.translations['components.controls.blocktype.blockquote'],
+    },
   ];
 
   renderFlat(): void {
     const { config: { className }, onChange, currentState: { blockType } } = this.props;
     return (
       <div className={classNames('rdw-inline-wrapper', className)}>
-        {
-        this.blocksTypes.map((block, index) =>
+        {this.blocksTypes.map((block, index) => (
           <Option
             key={index}
             value={block.label}
@@ -45,8 +50,7 @@ class LayoutComponent extends Component {
           >
             {block.displayName}
           </Option>
-        )
-      }
+        ))}
       </div>
     );
   }
@@ -76,16 +80,11 @@ class LayoutComponent extends Component {
           onExpandEvent={onExpandEvent}
         >
           <span>{currentLabel || translations['components.controls.blocktype.blocktype']}</span>
-          {
-            this.blocksTypes.map((block, index) =>
-              <DropdownOption
-                active={blockType === block.label}
-                value={block.label}
-                key={index}
-              >
-                {block.displayName}
-              </DropdownOption>)
-          }
+          {this.blocksTypes.map((block, index) => (
+            <DropdownOption active={blockType === block.label} value={block.label} key={index}>
+              {block.displayName}
+            </DropdownOption>
+          ))}
         </Dropdown>
       </div>
     );

--- a/js/src/components/Controls/BlockType/index.js
+++ b/js/src/components/Controls/BlockType/index.js
@@ -1,13 +1,13 @@
 /* @flow */
 
-import React, { Component, PropTypes } from 'react';
+import React, { Component } from 'react';
+import PropTypes from 'prop-types';
 import { getSelectedBlocksType } from 'draftjs-utils';
 import { RichUtils } from 'draft-js';
 
 import LayoutComponent from './Component';
 
 class BlockType extends Component {
-
   static propTypes = {
     onChange: PropTypes.func.isRequired,
     editorState: PropTypes.object,
@@ -32,8 +32,7 @@ class BlockType extends Component {
   }
 
   componentWillReceiveProps(properties: Object): void {
-    if (properties.editorState &&
-      this.props.editorState !== properties.editorState) {
+    if (properties.editorState && this.props.editorState !== properties.editorState) {
       this.setState({
         currentBlockType: getSelectedBlocksType(properties.editorState),
       });
@@ -61,7 +60,7 @@ class BlockType extends Component {
       expanded: this.signalExpanded,
     });
     this.signalExpanded = false;
-  }
+  };
 
   onExpandEvent: Function = (): void => {
     this.signalExpanded = !this.state.expanded;
@@ -82,10 +81,7 @@ class BlockType extends Component {
   toggleBlockType: Function = (blockType: string) => {
     const blockTypeValue = this.blocksTypes.find(bt => bt.label === blockType).style;
     const { editorState, onChange } = this.props;
-    const newState = RichUtils.toggleBlockType(
-      editorState,
-      blockTypeValue,
-    );
+    const newState = RichUtils.toggleBlockType(editorState, blockTypeValue);
     if (newState) {
       onChange(newState);
     }
@@ -93,7 +89,7 @@ class BlockType extends Component {
 
   render(): Object {
     const { config, translations } = this.props;
-    const { undoDisabled, redoDisabled, expanded, currentBlockType } = this.state
+    const { undoDisabled, redoDisabled, expanded, currentBlockType } = this.state;
     const BlockTypeComponent = config.component || LayoutComponent;
     const blockType = this.blocksTypes.find(bt => bt.style === currentBlockType);
     return (

--- a/js/src/components/Controls/ColorPicker/Component/index.js
+++ b/js/src/components/Controls/ColorPicker/Component/index.js
@@ -1,6 +1,7 @@
 /* @flow */
 
-import React, { Component, PropTypes } from 'react';
+import React, { Component } from 'react';
+import PropTypes from 'prop-types';
 import classNames from 'classnames';
 
 import { stopPropagation } from '../../../../utils/common';
@@ -8,7 +9,6 @@ import Option from '../../../Option';
 import styles from './styles.css'; // eslint-disable-line no-unused-vars
 
 class LayoutComponent extends Component {
-
   static propTypes = {
     expanded: PropTypes.bool,
     onExpandEvent: PropTypes.func,
@@ -46,12 +46,16 @@ class LayoutComponent extends Component {
     const { onChange } = this.props;
     const { currentStyle } = this.state;
     onChange(currentStyle, color);
-  }
+  };
 
   renderModal: Function = (): Object => {
-    const { config: { popupClassName, colors }, currentState: { color, bgColor }, translations } = this.props;
+    const {
+      config: { popupClassName, colors },
+      currentState: { color, bgColor },
+      translations,
+    } = this.props;
     const { currentStyle } = this.state;
-    const currentSelectedColor = (currentStyle === 'color') ? color : bgColor;
+    const currentSelectedColor = currentStyle === 'color' ? color : bgColor;
     return (
       <div
         className={classNames('rdw-colorpicker-modal', popupClassName)}
@@ -59,41 +63,35 @@ class LayoutComponent extends Component {
       >
         <span className="rdw-colorpicker-modal-header">
           <span
-            className={classNames(
-              'rdw-colorpicker-modal-style-label',
-              { 'rdw-colorpicker-modal-style-label-active': currentStyle === 'color' }
-            )}
+            className={classNames('rdw-colorpicker-modal-style-label', {
+              'rdw-colorpicker-modal-style-label-active': currentStyle === 'color',
+            })}
             onClick={this.setCurrentStyleColor}
           >
             {translations['components.controls.colorpicker.text']}
           </span>
           <span
-            className={classNames(
-              'rdw-colorpicker-modal-style-label',
-              { 'rdw-colorpicker-modal-style-label-active': currentStyle === 'bgcolor' }
-            )}
+            className={classNames('rdw-colorpicker-modal-style-label', {
+              'rdw-colorpicker-modal-style-label-active': currentStyle === 'bgcolor',
+            })}
             onClick={this.setCurrentStyleBgcolor}
           >
             {translations['components.controls.colorpicker.background']}
           </span>
         </span>
         <span className="rdw-colorpicker-modal-options">
-          {
-            colors.map((color, index) =>
-              <Option
-                value={color}
-                key={index}
-                className="rdw-colorpicker-option"
-                activeClassName="rdw-colorpicker-option-active"
-                active={currentSelectedColor === color}
-                onClick={this.onChange}
-              >
-                <span
-                  style={{ backgroundColor: color }}
-                  className="rdw-colorpicker-cube"
-                />
-              </Option>)
-          }
+          {colors.map((color, index) => (
+            <Option
+              value={color}
+              key={index}
+              className="rdw-colorpicker-option"
+              activeClassName="rdw-colorpicker-option-active"
+              active={currentSelectedColor === color}
+              onClick={this.onChange}
+            >
+              <span style={{ backgroundColor: color }} className="rdw-colorpicker-cube" />
+            </Option>
+          ))}
         </span>
       </div>
     );
@@ -108,14 +106,8 @@ class LayoutComponent extends Component {
         aria-expanded={expanded}
         aria-label="rdw-color-picker"
       >
-        <Option
-          onClick={onExpandEvent}
-          className={classNames(className)}
-        >
-          <img
-            src={icon}
-            alt=""
-          />
+        <Option onClick={onExpandEvent} className={classNames(className)}>
+          <img src={icon} alt="" />
         </Option>
         {expanded ? this.renderModal() : undefined}
       </div>

--- a/js/src/components/Controls/ColorPicker/index.js
+++ b/js/src/components/Controls/ColorPicker/index.js
@@ -1,15 +1,12 @@
 /* @flow */
 
-import React, { Component, PropTypes } from 'react';
-import {
-  toggleCustomInlineStyle,
-  getSelectionCustomInlineStyle,
-} from 'draftjs-utils';
+import React, { Component } from 'react';
+import PropTypes from 'prop-types';
+import { toggleCustomInlineStyle, getSelectionCustomInlineStyle } from 'draftjs-utils';
 
 import LayoutComponent from './Component';
 
 class ColorPicker extends Component {
-
   static propTypes = {
     onChange: PropTypes.func.isRequired,
     editorState: PropTypes.object.isRequired,
@@ -37,12 +34,13 @@ class ColorPicker extends Component {
 
   componentWillReceiveProps(properties: Object): void {
     const newState = {};
-    if (properties.editorState &&
-      this.props.editorState !== properties.editorState) {
-      newState.currentColor
-        = getSelectionCustomInlineStyle(properties.editorState, ['COLOR']).COLOR;
-      newState.currentBgColor
-        = getSelectionCustomInlineStyle(properties.editorState, ['BGCOLOR']).BGCOLOR;
+    if (properties.editorState && this.props.editorState !== properties.editorState) {
+      newState.currentColor = getSelectionCustomInlineStyle(properties.editorState, [
+        'COLOR',
+      ]).COLOR;
+      newState.currentBgColor = getSelectionCustomInlineStyle(properties.editorState, [
+        'BGCOLOR',
+      ]).BGCOLOR;
     }
     this.setState(newState);
   }
@@ -57,7 +55,7 @@ class ColorPicker extends Component {
       expanded: this.signalExpanded,
     });
     this.signalExpanded = false;
-  }
+  };
 
   onExpandEvent: Function = (): void => {
     this.signalExpanded = !this.state.expanded;
@@ -77,11 +75,7 @@ class ColorPicker extends Component {
 
   toggleColor: Function = (style: string, color: string): void => {
     const { editorState, onChange } = this.props;
-    const newState = toggleCustomInlineStyle(
-      editorState,
-      style,
-      color,
-    );
+    const newState = toggleCustomInlineStyle(editorState, style, color);
     if (newState) {
       onChange(newState);
     }
@@ -90,7 +84,7 @@ class ColorPicker extends Component {
 
   render(): Object {
     const { config, translations } = this.props;
-    const { currentColor, currentBgColor, expanded } = this.state
+    const { currentColor, currentBgColor, expanded } = this.state;
     const ColorPickerComponent = config.component || LayoutComponent;
     const color = currentColor && currentColor.substring(6);
     const bgColor = currentBgColor && currentBgColor.substring(8);

--- a/js/src/components/Controls/Embedded/Component/index.js
+++ b/js/src/components/Controls/Embedded/Component/index.js
@@ -1,6 +1,7 @@
 /* @flow */
 
-import React, { Component, PropTypes } from 'react';
+import React, { Component } from 'react';
+import PropTypes from 'prop-types';
 import classNames from 'classnames';
 
 import { stopPropagation } from '../../../../utils/common';
@@ -8,7 +9,6 @@ import Option from '../../../Option';
 import styles from './styles.css'; // eslint-disable-line no-unused-vars
 
 class LayoutComponent extends Component {
-
   static propTypes: Object = {
     expanded: PropTypes.bool,
     onExpandEvent: PropTypes.func,
@@ -29,8 +29,8 @@ class LayoutComponent extends Component {
       const { height, width } = this.props.config.defaultSize;
       this.setState({
         embeddedLink: '',
-        height: height,
-        width: width,
+        height,
+        width,
       });
     }
   }
@@ -51,10 +51,7 @@ class LayoutComponent extends Component {
     const { embeddedLink, height, width } = this.state;
     const { config: { popupClassName }, doCollapse, translations } = this.props;
     return (
-      <div
-        className={classNames('rdw-embedded-modal', popupClassName)}
-        onClick={stopPropagation}
-      >
+      <div className={classNames('rdw-embedded-modal', popupClassName)} onClick={stopPropagation}>
         <div className="rdw-embedded-modal-header">
           <span className="rdw-embedded-modal-header-option">
             {translations['components.controls.embedded.embeddedlink']}
@@ -97,10 +94,7 @@ class LayoutComponent extends Component {
           >
             {translations['generic.add']}
           </button>
-          <button
-            className="rdw-embedded-modal-btn"
-            onClick={doCollapse}
-          >
+          <button className="rdw-embedded-modal-btn" onClick={doCollapse}>
             {translations['generic.cancel']}
           </button>
         </span>
@@ -122,10 +116,7 @@ class LayoutComponent extends Component {
           value="unordered-list-item"
           onClick={onExpandEvent}
         >
-          <img
-            src={icon}
-            alt=""
-          />
+          <img src={icon} alt="" />
         </Option>
         {expanded ? this.rendeEmbeddedLinkModal() : undefined}
       </div>

--- a/js/src/components/Controls/Embedded/index.js
+++ b/js/src/components/Controls/Embedded/index.js
@@ -1,12 +1,12 @@
 /* @flow */
 
-import React, { Component, PropTypes } from 'react';
+import React, { Component } from 'react';
+import PropTypes from 'prop-types';
 import { Entity, AtomicBlockUtils } from 'draft-js';
 
 import LayoutComponent from './Component';
 
 class Embedded extends Component {
-
   static propTypes: Object = {
     editorState: PropTypes.object.isRequired,
     onChange: PropTypes.func.isRequired,
@@ -34,7 +34,7 @@ class Embedded extends Component {
       expanded: this.signalExpanded,
     });
     this.signalExpanded = false;
-  }
+  };
 
   onExpandEvent: Function = (): void => {
     this.signalExpanded = !this.state.expanded;
@@ -58,18 +58,14 @@ class Embedded extends Component {
       .getCurrentContent()
       .createEntity('EMBEDDED_LINK', 'MUTABLE', { src: embeddedLink, height, width })
       .getLastCreatedEntityKey();
-    const newEditorState = AtomicBlockUtils.insertAtomicBlock(
-      editorState,
-      entityKey,
-      ' '
-    );
+    const newEditorState = AtomicBlockUtils.insertAtomicBlock(editorState, entityKey, ' ');
     onChange(newEditorState);
     this.doCollapse();
   };
 
   render(): Object {
     const { config, translations } = this.props;
-    const { expanded } = this.state
+    const { expanded } = this.state;
     const EmbeddedComponent = config.component || LayoutComponent;
     return (
       <EmbeddedComponent

--- a/js/src/components/Controls/Emoji/Component/index.js
+++ b/js/src/components/Controls/Emoji/Component/index.js
@@ -1,6 +1,7 @@
 /* @flow */
 
-import React, { Component, PropTypes } from 'react';
+import React, { Component } from 'react';
+import PropTypes from 'prop-types';
 import classNames from 'classnames';
 
 import { stopPropagation } from '../../../../utils/common';
@@ -8,7 +9,6 @@ import Option from '../../../Option';
 import styles from './styles.css'; // eslint-disable-line no-unused-vars
 
 class LayoutComponent extends Component {
-
   static propTypes: Object = {
     expanded: PropTypes.bool,
     onExpandEvent: PropTypes.func,
@@ -24,18 +24,10 @@ class LayoutComponent extends Component {
   renderEmojiModal(): Object {
     const { config: { popupClassName, emojis } } = this.props;
     return (
-      <div
-        className={classNames('rdw-emoji-modal', popupClassName)}
-        onClick={stopPropagation}
-      >
-        {
-          emojis.map((emoji, index) => (<span
-            key={index}
-            className="rdw-emoji-icon"
-            alt=""
-            onClick={this.onChange}
-          >{emoji}</span>))
-        }
+      <div className={classNames('rdw-emoji-modal', popupClassName)} onClick={stopPropagation}>
+        {emojis.map((emoji, index) => (
+          <span key={index} className="rdw-emoji-icon" alt="" onClick={this.onChange}>{emoji}</span>
+        ))}
       </div>
     );
   }
@@ -54,10 +46,7 @@ class LayoutComponent extends Component {
           value="unordered-list-item"
           onClick={onExpandEvent}
         >
-          <img
-            src={icon}
-            alt=""
-          />
+          <img src={icon} alt="" />
         </Option>
         {expanded ? this.renderEmojiModal() : undefined}
       </div>

--- a/js/src/components/Controls/Emoji/index.js
+++ b/js/src/components/Controls/Emoji/index.js
@@ -1,12 +1,12 @@
 /* @flow */
 
-import React, { Component, PropTypes } from 'react';
+import React, { Component } from 'react';
+import PropTypes from 'prop-types';
 import { Modifier, EditorState } from 'draft-js';
 
 import LayoutComponent from './Component';
 
 export default class Emoji extends Component {
-
   static propTypes: Object = {
     editorState: PropTypes.object.isRequired,
     onChange: PropTypes.func.isRequired,
@@ -34,7 +34,7 @@ export default class Emoji extends Component {
       expanded: this.signalExpanded,
     });
     this.signalExpanded = false;
-  }
+  };
 
   onExpandEvent: Function = (): void => {
     this.signalExpanded = !this.state.expanded;
@@ -66,7 +66,7 @@ export default class Emoji extends Component {
 
   render(): Object {
     const { config, translations } = this.props;
-    const { expanded } = this.state
+    const { expanded } = this.state;
     const EmojiComponent = config.component || LayoutComponent;
     return (
       <EmojiComponent

--- a/js/src/components/Controls/FontFamily/Component/index.js
+++ b/js/src/components/Controls/FontFamily/Component/index.js
@@ -1,13 +1,13 @@
 /* @flow */
 
-import React, { Component, PropTypes } from 'react';
+import React, { Component } from 'react';
+import PropTypes from 'prop-types';
 import classNames from 'classnames';
 
 import { Dropdown, DropdownOption } from '../../../Dropdown';
 import styles from './styles.css'; // eslint-disable-line no-unused-vars
 
 class LayoutComponent extends Component {
-
   static propTypes = {
     expanded: PropTypes.bool,
     onExpandEvent: PropTypes.func,
@@ -45,9 +45,13 @@ class LayoutComponent extends Component {
       onExpandEvent,
       doExpand,
     } = this.props;
-    let { currentState: { fontFamily : currentFontFamily } } = this.props;
-    currentFontFamily = currentFontFamily ||
-      (options && defaultFontFamily && options.some(opt => opt.toLowerCase() === defaultFontFamily.toLowerCase()) && defaultFontFamily);
+    let { currentState: { fontFamily: currentFontFamily } } = this.props;
+    currentFontFamily =
+      currentFontFamily ||
+      (options &&
+        defaultFontFamily &&
+        options.some(opt => opt.toLowerCase() === defaultFontFamily.toLowerCase()) &&
+        defaultFontFamily);
     return (
       <div className="rdw-fontfamily-wrapper" aria-label="rdw-font-family-control">
         <Dropdown
@@ -62,16 +66,11 @@ class LayoutComponent extends Component {
           <span className="rdw-fontfamily-placeholder">
             {currentFontFamily || translations['components.controls.fontfamily.fontfamily']}
           </span>
-          {
-            options.map((family, index) =>
-              <DropdownOption
-                active={currentFontFamily === family}
-                value={family}
-                key={index}
-              >
-                {family}
-              </DropdownOption>)
-          }
+          {options.map((family, index) => (
+            <DropdownOption active={currentFontFamily === family} value={family} key={index}>
+              {family}
+            </DropdownOption>
+          ))}
         </Dropdown>
       </div>
     );

--- a/js/src/components/Controls/FontFamily/index.js
+++ b/js/src/components/Controls/FontFamily/index.js
@@ -1,15 +1,12 @@
 /* @flow */
 
-import React, { Component, PropTypes } from 'react';
-import {
-  toggleCustomInlineStyle,
-  getSelectionCustomInlineStyle,
-} from 'draftjs-utils';
+import React, { Component } from 'react';
+import PropTypes from 'prop-types';
+import { toggleCustomInlineStyle, getSelectionCustomInlineStyle } from 'draftjs-utils';
 
 import LayoutComponent from './Component';
 
 export default class FontFamily extends Component {
-
   static propTypes = {
     onChange: PropTypes.func.isRequired,
     editorState: PropTypes.object,
@@ -34,11 +31,10 @@ export default class FontFamily extends Component {
   }
 
   componentWillReceiveProps(properties: Object): void {
-    if (properties.editorState &&
-      this.props.editorState !== properties.editorState) {
+    if (properties.editorState && this.props.editorState !== properties.editorState) {
       this.setState({
-        currentFontFamily:
-          getSelectionCustomInlineStyle(properties.editorState, ['FONTFAMILY']).FONTFAMILY,
+        currentFontFamily: getSelectionCustomInlineStyle(properties.editorState, ['FONTFAMILY'])
+          .FONTFAMILY,
       });
     }
   }
@@ -53,7 +49,7 @@ export default class FontFamily extends Component {
       expanded: this.signalExpanded,
     });
     this.signalExpanded = false;
-  }
+  };
 
   onExpandEvent: Function = (): void => {
     this.signalExpanded = !this.state.expanded;
@@ -73,11 +69,7 @@ export default class FontFamily extends Component {
 
   toggleFontFamily: Function = (fontFamily: string) => {
     const { editorState, onChange } = this.props;
-    const newState = toggleCustomInlineStyle(
-      editorState,
-      'fontFamily',
-      fontFamily,
-    );
+    const newState = toggleCustomInlineStyle(editorState, 'fontFamily', fontFamily);
     if (newState) {
       onChange(newState);
     }
@@ -85,7 +77,7 @@ export default class FontFamily extends Component {
 
   render(): Object {
     const { config, translations } = this.props;
-    const { undoDisabled, redoDisabled, expanded, currentFontFamily } = this.state
+    const { undoDisabled, redoDisabled, expanded, currentFontFamily } = this.state;
     const FontFamilyComponent = config.component || LayoutComponent;
     const fontFamily = currentFontFamily && currentFontFamily.substring(11);
     return (

--- a/js/src/components/Controls/FontSize/Component/index.js
+++ b/js/src/components/Controls/FontSize/Component/index.js
@@ -1,13 +1,13 @@
 /* @flow */
 
-import React, { Component, PropTypes } from 'react';
+import React, { Component } from 'react';
+import PropTypes from 'prop-types';
 import classNames from 'classnames';
 
 import { Dropdown, DropdownOption } from '../../../Dropdown';
 import styles from './styles.css'; // eslint-disable-line no-unused-vars
 
 export default class LayoutComponent extends Component {
-
   static propTypes = {
     expanded: PropTypes.bool,
     onExpandEvent: PropTypes.func,
@@ -44,11 +44,11 @@ export default class LayoutComponent extends Component {
       onExpandEvent,
       doExpand,
     } = this.props;
-    let { currentState: { fontSize : currentFontSize} } = this.props;
+    let { currentState: { fontSize: currentFontSize } } = this.props;
     let { defaultFontSize } = this.state;
     defaultFontSize = Number(defaultFontSize);
-    currentFontSize = currentFontSize ||
-      (options && options.indexOf(defaultFontSize) >= 0 && defaultFontSize);
+    currentFontSize =
+      currentFontSize || (options && options.indexOf(defaultFontSize) >= 0 && defaultFontSize);
     return (
       <div className="rdw-fontsize-wrapper" aria-label="rdw-font-size-control">
         <Dropdown
@@ -60,26 +60,17 @@ export default class LayoutComponent extends Component {
           doCollapse={doCollapse}
           onExpandEvent={onExpandEvent}
         >
-          {currentFontSize ?
-            <span>{currentFontSize}</span>
-          :
-            <img
-              src={icon}
-              alt=""
-            />
-          }
-          {
-            options.map((size, index) =>
-              <DropdownOption
-                className="rdw-fontsize-option"
-                active={currentFontSize === size}
-                value={size}
-                key={index}
-              >
-                {size}
-              </DropdownOption>
-            )
-          }
+          {currentFontSize ? <span>{currentFontSize}</span> : <img src={icon} alt="" />}
+          {options.map((size, index) => (
+            <DropdownOption
+              className="rdw-fontsize-option"
+              active={currentFontSize === size}
+              value={size}
+              key={index}
+            >
+              {size}
+            </DropdownOption>
+          ))}
         </Dropdown>
       </div>
     );

--- a/js/src/components/Controls/FontSize/index.js
+++ b/js/src/components/Controls/FontSize/index.js
@@ -1,16 +1,12 @@
 /* @flow */
 
-import React, { Component, PropTypes } from 'react';
-import {
-  fontSizes,
-  toggleCustomInlineStyle,
-  getSelectionCustomInlineStyle,
-} from 'draftjs-utils';
+import React, { Component } from 'react';
+import PropTypes from 'prop-types';
+import { fontSizes, toggleCustomInlineStyle, getSelectionCustomInlineStyle } from 'draftjs-utils';
 
 import LayoutComponent from './Component';
 
 export default class FontSize extends Component {
-
   static propTypes = {
     onChange: PropTypes.func.isRequired,
     editorState: PropTypes.object,
@@ -28,8 +24,7 @@ export default class FontSize extends Component {
     const { editorState, modalHandler } = this.props;
     if (editorState) {
       this.setState({
-        currentFontSize:
-          getSelectionCustomInlineStyle(editorState, ['FONTSIZE']).FONTSIZE,
+        currentFontSize: getSelectionCustomInlineStyle(editorState, ['FONTSIZE']).FONTSIZE,
       });
     }
     modalHandler.registerCallBack(this.expandCollapse);
@@ -48,11 +43,10 @@ export default class FontSize extends Component {
   }
 
   componentWillReceiveProps(properties: Object): void {
-    if (properties.editorState &&
-      this.props.editorState !== properties.editorState) {
+    if (properties.editorState && this.props.editorState !== properties.editorState) {
       this.setState({
-        currentFontSize:
-          getSelectionCustomInlineStyle(properties.editorState, ['FONTSIZE']).FONTSIZE,
+        currentFontSize: getSelectionCustomInlineStyle(properties.editorState, ['FONTSIZE'])
+          .FONTSIZE,
       });
     }
   }
@@ -67,7 +61,7 @@ export default class FontSize extends Component {
       expanded: this.signalExpanded,
     });
     this.signalExpanded = false;
-  }
+  };
 
   onExpandEvent: Function = (): void => {
     this.signalExpanded = !this.state.expanded;
@@ -87,11 +81,7 @@ export default class FontSize extends Component {
 
   toggleFontSize: Function = (fontSize: number) => {
     const { editorState, onChange } = this.props;
-    const newState = toggleCustomInlineStyle(
-      editorState,
-      'fontSize',
-      fontSize,
-    );
+    const newState = toggleCustomInlineStyle(editorState, 'fontSize', fontSize);
     if (newState) {
       onChange(newState);
     }
@@ -99,7 +89,7 @@ export default class FontSize extends Component {
 
   render(): Object {
     const { config, translations } = this.props;
-    const { undoDisabled, redoDisabled, expanded, currentFontSize } = this.state
+    const { undoDisabled, redoDisabled, expanded, currentFontSize } = this.state;
     const FontSizeComponent = config.component || LayoutComponent;
     const fontSize = currentFontSize && Number(currentFontSize.substring(9));
     return (

--- a/js/src/components/Controls/History/Component/index.js
+++ b/js/src/components/Controls/History/Component/index.js
@@ -1,6 +1,7 @@
 /* @flow */
 
-import React, { Component, PropTypes } from 'react';
+import React, { Component } from 'react';
+import PropTypes from 'prop-types';
 import classNames from 'classnames';
 
 import { getFirstIcon } from '../../../../utils/toolbar';
@@ -9,7 +10,6 @@ import { Dropdown, DropdownOption } from '../../../Dropdown';
 import styles from './styles.css'; // eslint-disable-line no-unused-vars
 
 export default class History extends Component {
-
   static propTypes = {
     expanded: PropTypes.bool,
     doExpand: PropTypes.func,
@@ -23,7 +23,7 @@ export default class History extends Component {
   onChange = (obj) => {
     const { onChange } = this.props;
     onChange(obj);
-  }
+  };
 
   renderInDropDown(): Object {
     const {
@@ -32,9 +32,9 @@ export default class History extends Component {
       doExpand,
       onExpandEvent,
       doCollapse,
-      currentState : { undoDisabled, redoDisabled },
+      currentState: { undoDisabled, redoDisabled },
     } = this.props;
-    const {options, undo, redo, className, dropdownClassName} = config;
+    const { options, undo, redo, className, dropdownClassName } = config;
     return (
       <Dropdown
         className={classNames('rdw-history-dropdown', className)}
@@ -45,32 +45,25 @@ export default class History extends Component {
         onExpandEvent={onExpandEvent}
         aria-label="rdw-history-control"
       >
-        <img
-          src={getFirstIcon(config)}
-          alt=""
-        />
-        {options.indexOf('undo') >= 0 && <DropdownOption
-          value="undo"
-          onClick={this.onChange}
-          disabled={undoDisabled}
-          className={classNames('rdw-history-dropdownoption', undo.className)}
-        >
-          <img
-            src={undo.icon}
-            alt=""
-          />
-        </DropdownOption>}
-        {options.indexOf('redo') >= 0 && <DropdownOption
-          value="redo"
-          onClick={this.onChange}
-          disabled={redoDisabled}
-          className={classNames('rdw-history-dropdownoption', redo.className)}
-        >
-          <img
-            src={redo.icon}
-            alt=""
-          />
-        </DropdownOption>}
+        <img src={getFirstIcon(config)} alt="" />
+        {options.indexOf('undo') >= 0 &&
+          <DropdownOption
+            value="undo"
+            onClick={this.onChange}
+            disabled={undoDisabled}
+            className={classNames('rdw-history-dropdownoption', undo.className)}
+          >
+            <img src={undo.icon} alt="" />
+          </DropdownOption>}
+        {options.indexOf('redo') >= 0 &&
+          <DropdownOption
+            value="redo"
+            onClick={this.onChange}
+            disabled={redoDisabled}
+            className={classNames('rdw-history-dropdownoption', redo.className)}
+          >
+            <img src={redo.icon} alt="" />
+          </DropdownOption>}
       </Dropdown>
     );
   }
@@ -81,29 +74,28 @@ export default class History extends Component {
       currentState: { undoDisabled, redoDisabled },
     } = this.props;
     return (
-      <div className={classNames('rdw-history-wrapper', className)} aria-label="rdw-history-control">
-        {options.indexOf('undo') >= 0 && <Option
-          value="undo"
-          onClick={this.onChange}
-          className={classNames(undo.className)}
-          disabled={undoDisabled}
-        >
-          <img
-            src={undo.icon}
-            alt=""
-          />
-        </Option>}
-        {options.indexOf('redo') >= 0 && <Option
-          value="redo"
-          onClick={this.onChange}
-          className={classNames(redo.className)}
-          disabled={redoDisabled}
-        >
-          <img
-            src={redo.icon}
-            alt=""
-          />
-        </Option>}
+      <div
+        className={classNames('rdw-history-wrapper', className)}
+        aria-label="rdw-history-control"
+      >
+        {options.indexOf('undo') >= 0 &&
+          <Option
+            value="undo"
+            onClick={this.onChange}
+            className={classNames(undo.className)}
+            disabled={undoDisabled}
+          >
+            <img src={undo.icon} alt="" />
+          </Option>}
+        {options.indexOf('redo') >= 0 &&
+          <Option
+            value="redo"
+            onClick={this.onChange}
+            className={classNames(redo.className)}
+            disabled={redoDisabled}
+          >
+            <img src={redo.icon} alt="" />
+          </Option>}
       </div>
     );
   }

--- a/js/src/components/Controls/History/index.js
+++ b/js/src/components/Controls/History/index.js
@@ -1,12 +1,12 @@
 /* @flow */
 
-import React, { Component, PropTypes } from 'react';
+import React, { Component } from 'react';
+import PropTypes from 'prop-types';
 import { EditorState } from 'draft-js';
 
 import LayoutComponent from './Component';
 
 export default class History extends Component {
-
   static propTypes = {
     onChange: PropTypes.func.isRequired,
     editorState: PropTypes.object,
@@ -32,8 +32,7 @@ export default class History extends Component {
   }
 
   componentWillReceiveProps(properties: Object): void {
-    if (properties.editorState &&
-      this.props.editorState !== properties.editorState) {
+    if (properties.editorState && this.props.editorState !== properties.editorState) {
       this.setState({
         undoDisabled: properties.editorState.getUndoStack().size === 0,
         redoDisabled: properties.editorState.getRedoStack().size === 0,
@@ -51,7 +50,7 @@ export default class History extends Component {
       expanded: this.signalExpanded,
     });
     this.signalExpanded = false;
-  }
+  };
 
   onExpandEvent: Function = (): void => {
     this.signalExpanded = !this.state.expanded;
@@ -75,16 +74,16 @@ export default class History extends Component {
     if (newState) {
       onChange(newState);
     }
-  }
+  };
 
   render(): Object {
     const { config } = this.props;
-    const { undoDisabled, redoDisabled, expanded } = this.state
+    const { undoDisabled, redoDisabled, expanded } = this.state;
     const HistoryComponent = config.component || LayoutComponent;
     return (
       <HistoryComponent
         config={config}
-        currentState={{ undoDisabled, redoDisabled}}
+        currentState={{ undoDisabled, redoDisabled }}
         expanded={expanded}
         onExpandEvent={this.onExpandEvent}
         doExpand={this.doExpand}

--- a/js/src/components/Controls/Image/Component/index.js
+++ b/js/src/components/Controls/Image/Component/index.js
@@ -1,6 +1,7 @@
 /* @flow */
 
-import React, { Component, PropTypes } from 'react';
+import React, { Component } from 'react';
+import PropTypes from 'prop-types';
 import classNames from 'classnames';
 
 import Option from '../../../Option';
@@ -8,7 +9,6 @@ import Spinner from '../../../Spinner';
 import styles from './styles.css'; // eslint-disable-line no-unused-vars
 
 class LayoutComponent extends Component {
-
   static propTypes: Object = {
     expanded: PropTypes.bool,
     onExpandEvent: PropTypes.func,
@@ -36,9 +36,11 @@ class LayoutComponent extends Component {
         showImageLoading: false,
         height: this.props.config.defaultSize.height,
         width: this.props.config.defaultSize.width,
-      })
-    } else if (props.config.uploadCallback !== this.props.config.uploadCallback ||
-      props.config.uploadEnabled !== this.props.config.uploadEnabled) {
+      });
+    } else if (
+      props.config.uploadCallback !== this.props.config.uploadCallback ||
+      props.config.uploadEnabled !== this.props.config.uploadEnabled
+    ) {
       this.setState({
         uploadHighlighted: props.config.uploadEnabled && !!props.config.uploadCallback,
       });
@@ -114,7 +116,8 @@ class LayoutComponent extends Component {
           dragEnter: false,
         });
         this.addImageFromSrcLink(data.link);
-      }).catch(() => {
+      })
+      .catch(() => {
         this.setState({
           showImageLoading: false,
           dragEnter: false,
@@ -125,7 +128,7 @@ class LayoutComponent extends Component {
   fileUploadClick = (event) => {
     this.fileUpload = true;
     event.stopPropagation();
-  }
+  };
 
   stopPropagation: Function = (event: Object): void => {
     if (!this.fileUpload) {
@@ -138,79 +141,68 @@ class LayoutComponent extends Component {
 
   renderAddImageModal(): Object {
     const { imgSrc, uploadHighlighted, showImageLoading, dragEnter, height, width } = this.state;
-    const { config: { popupClassName, uploadCallback, uploadEnabled, urlEnabled }, doCollapse, translations } = this.props;
+    const {
+      config: { popupClassName, uploadCallback, uploadEnabled, urlEnabled },
+      doCollapse,
+      translations,
+    } = this.props;
     return (
-      <div
-        className={classNames('rdw-image-modal', popupClassName)}
-        onClick={this.stopPropagation}
-      >
+      <div className={classNames('rdw-image-modal', popupClassName)} onClick={this.stopPropagation}>
         <div className="rdw-image-modal-header">
-          {uploadEnabled && uploadCallback &&
-            <span
-              onClick={this.showImageUploadOption}
-              className="rdw-image-modal-header-option"
-            >
+          {uploadEnabled &&
+            uploadCallback &&
+            <span onClick={this.showImageUploadOption} className="rdw-image-modal-header-option">
               {translations['components.controls.image.fileUpload']}
               <span
-                className={classNames(
-                  'rdw-image-modal-header-label',
-                  { 'rdw-image-modal-header-label-highlighted': uploadHighlighted }
-                )}
+                className={classNames('rdw-image-modal-header-label', {
+                  'rdw-image-modal-header-label-highlighted': uploadHighlighted,
+                })}
               />
             </span>}
-          { urlEnabled &&
-            <span
-              onClick={this.showImageURLOption}
-              className="rdw-image-modal-header-option"
-            >
+          {urlEnabled &&
+            <span onClick={this.showImageURLOption} className="rdw-image-modal-header-option">
               {translations['components.controls.image.byURL']}
               <span
-                className={classNames(
-                  'rdw-image-modal-header-label',
-                  { 'rdw-image-modal-header-label-highlighted': !uploadHighlighted }
-                )}
+                className={classNames('rdw-image-modal-header-label', {
+                  'rdw-image-modal-header-label-highlighted': !uploadHighlighted,
+                })}
               />
             </span>}
         </div>
-        {
-          uploadHighlighted ?
-            <div onClick={this.fileUploadClick}>
-              <div
-                onDragEnter={this.onDragEnter}
-                onDragOver={this.stopPropagation}
-                onDrop={this.onImageDrop}
-                className={classNames(
-                'rdw-image-modal-upload-option',
-                { 'rdw-image-modal-upload-option-highlighted': dragEnter })}
-              >
-                <label
-                  htmlFor="file"
-                  className="rdw-image-modal-upload-option-label"
-                >
-                   {translations['components.controls.image.dropFileText']}
-                </label>
-              </div>
-              <input
-                type="file"
-                id="file"
-                accept="image/*"
-                onChange={this.selectImage}
-                className="rdw-image-modal-upload-option-input"
-              />
-            </div> :
-              <div className="rdw-image-modal-url-section">
-                <input
-                  className="rdw-image-modal-url-input"
-                  placeholder="Enter url"
-                  name="imgSrc"
-                  onChange={this.updateValue}
-                  onBlur={this.updateValue}
-                  value={imgSrc}
-                />
-              </div>
-        }
+        {uploadHighlighted
+          ? <div onClick={this.fileUploadClick}>
+            <div
+              onDragEnter={this.onDragEnter}
+              onDragOver={this.stopPropagation}
+              onDrop={this.onImageDrop}
+              className={classNames('rdw-image-modal-upload-option', {
+                'rdw-image-modal-upload-option-highlighted': dragEnter,
+              })}
+            >
+              <label htmlFor="file" className="rdw-image-modal-upload-option-label">
+                {translations['components.controls.image.dropFileText']}
+              </label>
+            </div>
+            <input
+              type="file"
+              id="file"
+              accept="image/*"
+              onChange={this.selectImage}
+              className="rdw-image-modal-upload-option-input"
+            />
+          </div>
+          : <div className="rdw-image-modal-url-section">
+            <input
+              className="rdw-image-modal-url-input"
+              placeholder="Enter url"
+              name="imgSrc"
+              onChange={this.updateValue}
+              onBlur={this.updateValue}
+              value={imgSrc}
+            />
+          </div>}
         <div className="rdw-embedded-modal-size">
-          &#8597;&nbsp;
+          ↕&nbsp;
           <input
             onChange={this.updateValue}
             onBlur={this.updateValue}
@@ -219,7 +211,7 @@ class LayoutComponent extends Component {
             className="rdw-embedded-modal-size-input"
             placeholder="Height"
           />
-          &nbsp;&#8596;&nbsp;
+          &nbsp;↔&nbsp;
           <input
             onChange={this.updateValue}
             onBlur={this.updateValue}
@@ -237,18 +229,15 @@ class LayoutComponent extends Component {
           >
             {translations['generic.add']}
           </button>
-          <button
-            className="rdw-image-modal-btn"
-            onClick={doCollapse}
-          >
+          <button className="rdw-image-modal-btn" onClick={doCollapse}>
             {translations['generic.cancel']}
           </button>
         </span>
-        {showImageLoading ?
-          <div className="rdw-image-modal-spinner">
+        {showImageLoading
+          ? <div className="rdw-image-modal-spinner">
             <Spinner />
-          </div> :
-          undefined}
+          </div>
+          : undefined}
       </div>
     );
   }
@@ -267,10 +256,7 @@ class LayoutComponent extends Component {
           value="unordered-list-item"
           onClick={onExpandEvent}
         >
-          <img
-            src={icon}
-            alt=""
-          />
+          <img src={icon} alt="" />
         </Option>
         {expanded ? this.renderAddImageModal() : undefined}
       </div>

--- a/js/src/components/Controls/Image/index.js
+++ b/js/src/components/Controls/Image/index.js
@@ -1,12 +1,12 @@
 /* @flow */
 
-import React, { Component, PropTypes } from 'react';
+import React, { Component } from 'react';
+import PropTypes from 'prop-types';
 import { Entity, AtomicBlockUtils } from 'draft-js';
 
 import LayoutComponent from './Component';
 
 class ImageControl extends Component {
-
   static propTypes: Object = {
     editorState: PropTypes.object.isRequired,
     onChange: PropTypes.func.isRequired,
@@ -34,7 +34,7 @@ class ImageControl extends Component {
       expanded: this.signalExpanded,
     });
     this.signalExpanded = false;
-  }
+  };
 
   onExpandEvent: Function = (): void => {
     this.signalExpanded = !this.state.expanded;
@@ -58,18 +58,14 @@ class ImageControl extends Component {
       .getCurrentContent()
       .createEntity('IMAGE', 'MUTABLE', { src, height, width })
       .getLastCreatedEntityKey();
-    const newEditorState = AtomicBlockUtils.insertAtomicBlock(
-      editorState,
-      entityKey,
-      ' '
-    );
+    const newEditorState = AtomicBlockUtils.insertAtomicBlock(editorState, entityKey, ' ');
     onChange(newEditorState);
     this.doCollapse();
   };
 
   render(): Object {
     const { config, translations } = this.props;
-    const { expanded } = this.state
+    const { expanded } = this.state;
     const ImageComponent = config.component || LayoutComponent;
     return (
       <ImageComponent

--- a/js/src/components/Controls/Inline/Component/index.js
+++ b/js/src/components/Controls/Inline/Component/index.js
@@ -1,6 +1,7 @@
 /* @flow */
 
-import React, { Component, PropTypes } from 'react';
+import React, { Component } from 'react';
+import PropTypes from 'prop-types';
 import classNames from 'classnames';
 
 import { getFirstIcon } from '../../../../utils/toolbar';
@@ -10,7 +11,6 @@ import { Dropdown, DropdownOption } from '../../../Dropdown';
 import styles from './styles.css'; // eslint-disable-line no-unused-vars
 
 export default class Inline extends Component {
-
   static propTypes = {
     expanded: PropTypes.bool,
     doExpand: PropTypes.func,
@@ -24,27 +24,21 @@ export default class Inline extends Component {
   renderInFlatList(): Object {
     const { config, currentState, onChange } = this.props;
     return (
-      <div className={classNames('rdw-inline-wrapper', config.className)} aria-label="rdw-inline-control">
-        {
-          config.options
-          .map((style, index) =>
-            <Option
-              key={index}
-              value={style}
-              onClick={onChange}
-              className={classNames(config[style].className)}
-              active={
-                currentState[style] === true ||
-                (style === 'MONOSPACE' && currentState['CODE'])
-              }
-            >
-              <img
-                alt=""
-                src={config[style].icon}
-              />
-            </Option>
-          )
-        }
+      <div
+        className={classNames('rdw-inline-wrapper', config.className)}
+        aria-label="rdw-inline-control"
+      >
+        {config.options.map((style, index) => (
+          <Option
+            key={index}
+            value={style}
+            onClick={onChange}
+            className={classNames(config[style].className)}
+            active={currentState[style] === true || (style === 'MONOSPACE' && currentState.CODE)}
+          >
+            <img alt="" src={config[style].icon} />
+          </Option>
+        ))}
       </div>
     );
   }
@@ -71,28 +65,17 @@ export default class Inline extends Component {
         onExpandEvent={onExpandEvent}
         aria-label="rdw-inline-control"
       >
-        <img
-          src={getFirstIcon(config)}
-          alt=""
-        />
-        {
-          config.options
-          .map((style, index) =>
-            <DropdownOption
-              key={index}
-              value={style}
-              className={classNames('rdw-inline-dropdownoption', config[style].className)}
-              active={
-                currentState[style] === true ||
-                (style === 'MONOSPACE' && currentState['CODE'])
-              }
-            >
-              <img
-                src={config[style].icon}
-                alt=""
-              />
-            </DropdownOption>)
-          }
+        <img src={getFirstIcon(config)} alt="" />
+        {config.options.map((style, index) => (
+          <DropdownOption
+            key={index}
+            value={style}
+            className={classNames('rdw-inline-dropdownoption', config[style].className)}
+            active={currentState[style] === true || (style === 'MONOSPACE' && currentState.CODE)}
+          >
+            <img src={config[style].icon} alt="" />
+          </DropdownOption>
+        ))}
       </Dropdown>
     );
   }

--- a/js/src/components/Controls/Inline/index.js
+++ b/js/src/components/Controls/Inline/index.js
@@ -1,6 +1,7 @@
 /* @flow */
 
-import React, { Component, PropTypes } from 'react';
+import React, { Component } from 'react';
+import PropTypes from 'prop-types';
 import { getSelectionInlineStyle } from 'draftjs-utils';
 import { RichUtils, EditorState, Modifier } from 'draft-js';
 import { forEach } from '../../../utils/common';
@@ -8,7 +9,6 @@ import { forEach } from '../../../utils/common';
 import LayoutComponent from './Component';
 
 export default class Inline extends Component {
-
   static propTypes = {
     onChange: PropTypes.func.isRequired,
     editorState: PropTypes.object.isRequired,
@@ -32,8 +32,7 @@ export default class Inline extends Component {
   }
 
   componentWillReceiveProps(properties: Object): void {
-    if (properties.editorState &&
-      this.props.editorState !== properties.editorState) {
+    if (properties.editorState && this.props.editorState !== properties.editorState) {
       this.setState({
         currentStyles: this.changeKeys(getSelectionInlineStyle(properties.editorState)),
       });
@@ -53,21 +52,18 @@ export default class Inline extends Component {
       });
       return st;
     }
-  }
+  };
 
   toggleInlineStyle: Function = (style: string): void => {
     const newStyle = style === 'monospace' ? 'CODE' : style.toUpperCase();
     const { editorState, onChange } = this.props;
-    let newState = RichUtils.toggleInlineStyle(
-      editorState,
-      newStyle
-    );
+    let newState = RichUtils.toggleInlineStyle(editorState, newStyle);
     if (style === 'subscript' || style === 'superscript') {
       const removeStyle = style === 'subscript' ? 'SUPERSCRIPT' : 'SUBSCRIPT';
       const contentState = Modifier.removeInlineStyle(
         newState.getCurrentContent(),
         newState.getSelection(),
-        removeStyle
+        removeStyle,
       );
       newState = EditorState.push(newState, contentState, 'change-inline-style');
     }
@@ -81,7 +77,7 @@ export default class Inline extends Component {
       expanded: this.signalExpanded,
     });
     this.signalExpanded = false;
-  }
+  };
 
   onExpandEvent: Function = (): void => {
     this.signalExpanded = !this.state.expanded;
@@ -101,7 +97,7 @@ export default class Inline extends Component {
 
   render(): Object {
     const { config, translations } = this.props;
-    const { expanded, currentStyles } = this.state
+    const { expanded, currentStyles } = this.state;
     const InlineComponent = config.component || LayoutComponent;
     return (
       <InlineComponent

--- a/js/src/components/Controls/Link/Component/index.js
+++ b/js/src/components/Controls/Link/Component/index.js
@@ -1,6 +1,7 @@
 /* @flow */
 
-import React, { Component, PropTypes } from 'react';
+import React, { Component } from 'react';
+import PropTypes from 'prop-types';
 import classNames from 'classnames';
 
 import { stopPropagation } from '../../../../utils/common';
@@ -10,7 +11,6 @@ import { Dropdown, DropdownOption } from '../../../Dropdown';
 import styles from './styles.css'; // eslint-disable-line no-unused-vars
 
 class LayoutComponent extends Component {
-
   static propTypes = {
     expanded: PropTypes.bool,
     doExpand: PropTypes.func,
@@ -79,7 +79,7 @@ class LayoutComponent extends Component {
       linkTargetOption: (link && link.targetOption) || linkTargetOption,
       linkTitle: (link && link.title) || selectionText,
     });
-  }
+  };
 
   forceExpandAndShowModal: Function = (): void => {
     const { doExpand, currentState: { link, selectionText } } = this.props;
@@ -91,16 +91,13 @@ class LayoutComponent extends Component {
       linkTargetOption: (link && link.targetOption) || linkTargetOption,
       linkTitle: (link && link.title) || selectionText,
     });
-  }
+  };
 
   renderAddLinkModal() {
     const { config: { popupClassName }, doCollapse, translations } = this.props;
     const { linkTitle, linkTarget, linkTargetOption } = this.state;
     return (
-      <div
-        className={classNames('rdw-link-modal', popupClassName)}
-        onClick={stopPropagation}
-      >
+      <div className={classNames('rdw-link-modal', popupClassName)} onClick={stopPropagation}>
         <span className="rdw-link-modal-label">
           {translations['components.controls.link.linkTitle']}
         </span>
@@ -138,10 +135,7 @@ class LayoutComponent extends Component {
           >
             {translations['generic.add']}
           </button>
-          <button
-            className="rdw-link-modal-btn"
-            onClick={doCollapse}
-          >
+          <button className="rdw-link-modal-btn" onClick={doCollapse}>
             {translations['generic.cancel']}
           </button>
         </span>
@@ -150,37 +144,29 @@ class LayoutComponent extends Component {
   }
 
   renderInFlatList(): Object {
-    const {
-      config: { options, link, unlink, className },
-      currentState,
-      expanded,
-    } = this.props;
+    const { config: { options, link, unlink, className }, currentState, expanded } = this.props;
     const { showModal } = this.state;
     return (
       <div className={classNames('rdw-link-wrapper', className)} aria-label="rdw-link-control">
-        {options.indexOf('link') >= 0 && <Option
-          value="unordered-list-item"
-          className={classNames(link.className)}
-          onClick={this.signalExpandShowModal}
-          aria-haspopup="true"
-          aria-expanded={showModal}
-        >
-          <img
-            src={link.icon}
-            alt=""
-          />
-        </Option>}
-        {options.indexOf('unlink') >= 0 && <Option
-          disabled={!currentState.link}
-          value="ordered-list-item"
-          className={classNames(unlink.className)}
-          onClick={this.removeLink}
-        >
-          <img
-            src={unlink.icon}
-            alt=""
-          />
-        </Option>}
+        {options.indexOf('link') >= 0 &&
+          <Option
+            value="unordered-list-item"
+            className={classNames(link.className)}
+            onClick={this.signalExpandShowModal}
+            aria-haspopup="true"
+            aria-expanded={showModal}
+          >
+            <img src={link.icon} alt="" />
+          </Option>}
+        {options.indexOf('unlink') >= 0 &&
+          <Option
+            disabled={!currentState.link}
+            value="ordered-list-item"
+            className={classNames(unlink.className)}
+            onClick={this.removeLink}
+          >
+            <img src={unlink.icon} alt="" />
+          </Option>}
         {expanded && showModal ? this.renderAddLinkModal() : undefined}
       </div>
     );
@@ -214,29 +200,22 @@ class LayoutComponent extends Component {
           doCollapse={doCollapse}
           onExpandEvent={onExpandEvent}
         >
-          <img
-            src={getFirstIcon(config)}
-            alt=""
-          />
-          {options.indexOf('link') >= 0 && <DropdownOption
-            onClick={this.forceExpandAndShowModal}
-            className={classNames('rdw-link-dropdownoption', link.className)}
-          >
-            <img
-              src={link.icon}
-              alt=""
-            />
-          </DropdownOption>}
-          {options.indexOf('unlink') >= 0 && <DropdownOption
-            onClick={this.removeLink}
-            disabled={!currentState.link}
-            className={classNames('rdw-link-dropdownoption', unlink.className)}
-          >
-            <img
-              src={unlink.icon}
-              alt=""
-            />
-          </DropdownOption>}
+          <img src={getFirstIcon(config)} alt="" />
+          {options.indexOf('link') >= 0 &&
+            <DropdownOption
+              onClick={this.forceExpandAndShowModal}
+              className={classNames('rdw-link-dropdownoption', link.className)}
+            >
+              <img src={link.icon} alt="" />
+            </DropdownOption>}
+          {options.indexOf('unlink') >= 0 &&
+            <DropdownOption
+              onClick={this.removeLink}
+              disabled={!currentState.link}
+              className={classNames('rdw-link-dropdownoption', unlink.className)}
+            >
+              <img src={unlink.icon} alt="" />
+            </DropdownOption>}
         </Dropdown>
         {expanded && showModal ? this.renderAddLinkModal() : undefined}
       </div>

--- a/js/src/components/Controls/Link/index.js
+++ b/js/src/components/Controls/Link/index.js
@@ -1,17 +1,13 @@
 /* @flow */
 
-import React, { Component, PropTypes } from 'react';
+import React, { Component } from 'react';
+import PropTypes from 'prop-types';
 import { Entity, RichUtils, EditorState, Modifier } from 'draft-js';
-import {
-  getSelectionText,
-  getEntityRange,
-  getSelectionEntity,
-} from 'draftjs-utils';
+import { getSelectionText, getEntityRange, getSelectionEntity } from 'draftjs-utils';
 
 import LayoutComponent from './Component';
 
 class Link extends Component {
-
   static propTypes = {
     editorState: PropTypes.object.isRequired,
     onChange: PropTypes.func.isRequired,
@@ -38,8 +34,7 @@ class Link extends Component {
 
   componentWillReceiveProps(properties: Object): void {
     const newState = {};
-    if (properties.editorState &&
-      this.props.editorState !== properties.editorState) {
+    if (properties.editorState && this.props.editorState !== properties.editorState) {
       newState.currentEntity = getSelectionEntity(properties.editorState);
     }
     this.setState(newState);
@@ -55,7 +50,7 @@ class Link extends Component {
       expanded: this.signalExpanded,
     });
     this.signalExpanded = false;
-  }
+  };
 
   onExpandEvent: Function = (): void => {
     this.signalExpanded = !this.state.expanded;
@@ -72,16 +67,18 @@ class Link extends Component {
     const { currentEntity } = this.state;
     const contentState = editorState.getCurrentContent();
     const currentValues = {};
-    if (currentEntity && (contentState.getEntity(currentEntity).get('type') === 'LINK')) {
+    if (currentEntity && contentState.getEntity(currentEntity).get('type') === 'LINK') {
       currentValues.link = {};
       const entityRange = currentEntity && getEntityRange(editorState, currentEntity);
-      currentValues.link.target = currentEntity && contentState.getEntity(currentEntity).get('data').url;
-      currentValues.link.targetOption = currentEntity && contentState.getEntity(currentEntity).get('data').target;
-      currentValues.link.title = (entityRange && entityRange.text);
+      currentValues.link.target =
+        currentEntity && contentState.getEntity(currentEntity).get('data').url;
+      currentValues.link.targetOption =
+        currentEntity && contentState.getEntity(currentEntity).get('data').target;
+      currentValues.link.title = entityRange && entityRange.text;
     }
     currentValues.selectionText = getSelectionText(editorState);
     return currentValues;
-  }
+  };
 
   doCollapse: Function = (): void => {
     this.setState({
@@ -95,7 +92,7 @@ class Link extends Component {
     } else {
       this.removeLink();
     }
-  }
+  };
 
   removeLink: Function = (): void => {
     const { editorState, onChange } = this.props;

--- a/js/src/components/Controls/List/Component/index.js
+++ b/js/src/components/Controls/List/Component/index.js
@@ -1,6 +1,7 @@
 /* @flow */
 
-import React, { Component, PropTypes } from 'react';
+import React, { Component } from 'react';
+import PropTypes from 'prop-types';
 import classNames from 'classnames';
 
 import { getFirstIcon } from '../../../../utils/toolbar';
@@ -9,7 +10,6 @@ import Option from '../../../Option';
 import styles from './styles.css'; // eslint-disable-line no-unused-vars
 
 export default class LayoutComponent extends Component {
-
   static propTypes = {
     expanded: PropTypes.bool,
     doExpand: PropTypes.func,
@@ -44,52 +44,46 @@ export default class LayoutComponent extends Component {
     const { options, unordered, ordered, indent, outdent, className } = config;
     return (
       <div className={classNames('rdw-list-wrapper', className)} aria-label="rdw-list-control">
-        {options.indexOf('unordered') >= 0 && <Option
-          value="unordered"
-          onClick={this.toggleBlockType}
-          className={classNames(unordered.className)}
-          active={listType === 'unordered'}
-        >
-          <img
-            src={unordered.icon}
-            alt=""
-          />
-        </Option>}
-        {options.indexOf('ordered') >= 0 && <Option
-          value="ordered"
-          onClick={this.toggleBlockType}
-          className={classNames(ordered.className)}
-          active={listType === 'ordered'}
-        >
-          <img
-            src={ordered.icon}
-            alt=""
-          />
-        </Option>}
-        {options.indexOf('indent') >= 0 && <Option
-          onClick={this.indent}
-          className={classNames(indent.className)}
-        >
-          <img
-            src={indent.icon}
-            alt=""
-          />
-        </Option>}
-        {options.indexOf('outdent') >= 0 && <Option
-          onClick={this.outdent}
-          className={classNames(outdent.className)}
-        >
-          <img
-            src={outdent.icon}
-            alt=""
-          />
-        </Option>}
+        {options.indexOf('unordered') >= 0 &&
+          <Option
+            value="unordered"
+            onClick={this.toggleBlockType}
+            className={classNames(unordered.className)}
+            active={listType === 'unordered'}
+          >
+            <img src={unordered.icon} alt="" />
+          </Option>}
+        {options.indexOf('ordered') >= 0 &&
+          <Option
+            value="ordered"
+            onClick={this.toggleBlockType}
+            className={classNames(ordered.className)}
+            active={listType === 'ordered'}
+          >
+            <img src={ordered.icon} alt="" />
+          </Option>}
+        {options.indexOf('indent') >= 0 &&
+          <Option onClick={this.indent} className={classNames(indent.className)}>
+            <img src={indent.icon} alt="" />
+          </Option>}
+        {options.indexOf('outdent') >= 0 &&
+          <Option onClick={this.outdent} className={classNames(outdent.className)}>
+            <img src={outdent.icon} alt="" />
+          </Option>}
       </div>
     );
   }
 
   renderInDropDown(): Object {
-    const { config, expanded, doCollapse, doExpand, onExpandEvent, onChange, currentState: { listType } } = this.props;
+    const {
+      config,
+      expanded,
+      doCollapse,
+      doExpand,
+      onExpandEvent,
+      onChange,
+      currentState: { listType },
+    } = this.props;
     const { options, className, dropdownClassName } = config;
     return (
       <Dropdown
@@ -102,24 +96,17 @@ export default class LayoutComponent extends Component {
         onExpandEvent={onExpandEvent}
         aria-label="rdw-list-control"
       >
-        <img
-          src={getFirstIcon(config)}
-          alt=""
-        />
-        { this.options
-          .filter(option => options.indexOf(option) >= 0)
-          .map((option, index) => (<DropdownOption
+        <img src={getFirstIcon(config)} alt="" />
+        {this.options.filter(option => options.indexOf(option) >= 0).map((option, index) => (
+          <DropdownOption
             key={index}
             value={option}
             className={classNames('rdw-list-dropdownOption', config[option].className)}
             active={listType === option}
           >
-            <img
-              src={config[option].icon}
-              alt=""
-            />
-          </DropdownOption>))
-        }
+            <img src={config[option].icon} alt="" />
+          </DropdownOption>
+        ))}
       </Dropdown>
     );
   }

--- a/js/src/components/Controls/List/index.js
+++ b/js/src/components/Controls/List/index.js
@@ -1,13 +1,13 @@
 /* @flow */
 
-import React, { Component, PropTypes } from 'react';
+import React, { Component } from 'react';
+import PropTypes from 'prop-types';
 import { RichUtils } from 'draft-js';
 import { changeDepth, getSelectedBlocksType } from 'draftjs-utils';
 
 import LayoutComponent from './Component';
 
 export default class List extends Component {
-
   static propTypes = {
     onChange: PropTypes.func.isRequired,
     editorState: PropTypes.object.isRequired,
@@ -32,8 +32,7 @@ export default class List extends Component {
   }
 
   componentWillReceiveProps(properties: Object): void {
-    if (properties.editorState &&
-      this.props.editorState !== properties.editorState) {
+    if (properties.editorState && this.props.editorState !== properties.editorState) {
       this.setState({
         currentBlockType: getSelectedBlocksType(properties.editorState),
       });
@@ -50,7 +49,7 @@ export default class List extends Component {
       expanded: this.signalExpanded,
     });
     this.signalExpanded = false;
-  }
+  };
 
   onExpandEvent: Function = (): void => {
     this.signalExpanded = !this.state.expanded;
@@ -82,10 +81,7 @@ export default class List extends Component {
 
   toggleBlockType: Function = (blockType: String): void => {
     const { onChange, editorState } = this.props;
-    const newState = RichUtils.toggleBlockType(
-      editorState,
-      blockType
-    );
+    const newState = RichUtils.toggleBlockType(editorState, blockType);
     if (newState) {
       onChange(newState);
     }
@@ -93,11 +89,7 @@ export default class List extends Component {
 
   adjustDepth: Function = (adjustment): void => {
     const { onChange, editorState } = this.props;
-    const newState = changeDepth(
-      editorState,
-      adjustment,
-      4,
-    );
+    const newState = changeDepth(editorState, adjustment, 4);
     if (newState) {
       onChange(newState);
     }
@@ -105,7 +97,7 @@ export default class List extends Component {
 
   render(): Object {
     const { config, translations } = this.props;
-    const { expanded, currentBlockType } = this.state
+    const { expanded, currentBlockType } = this.state;
     const ListComponent = config.component || LayoutComponent;
     let listType;
     if (currentBlockType === 'unordered-list-item') {

--- a/js/src/components/Controls/Remove/index.js
+++ b/js/src/components/Controls/Remove/index.js
@@ -1,6 +1,7 @@
 /* @flow */
 
-import React, { Component, PropTypes } from 'react';
+import React, { Component } from 'react';
+import PropTypes from 'prop-types';
 import { EditorState, Modifier } from 'draft-js';
 import { getSelectionCustomInlineStyle } from 'draftjs-utils';
 
@@ -8,7 +9,6 @@ import { forEach } from '../../../utils/common';
 import LayoutComponent from './Component';
 
 export default class Remove extends Component {
-
   static propTypes = {
     onChange: PropTypes.func.isRequired,
     editorState: PropTypes.object.isRequired,
@@ -18,7 +18,7 @@ export default class Remove extends Component {
 
   state = {
     expanded: false,
-  }
+  };
 
   componentWillMount(): void {
     const { modalHandler } = this.props;
@@ -41,22 +41,19 @@ export default class Remove extends Component {
       'SUPERSCRIPT',
       'SUBSCRIPT',
     ].forEach((style) => {
-      contentState = Modifier.removeInlineStyle(
-        contentState,
-        editorState.getSelection(),
-        style
-      );
+      contentState = Modifier.removeInlineStyle(contentState, editorState.getSelection(), style);
     });
-    const customStyles = getSelectionCustomInlineStyle(editorState, ['FONTSIZE', 'FONTFAMILY', 'COLOR', 'BGCOLOR']);
+    const customStyles = getSelectionCustomInlineStyle(editorState, [
+      'FONTSIZE',
+      'FONTFAMILY',
+      'COLOR',
+      'BGCOLOR',
+    ]);
     forEach(customStyles, (key, value) => {
       if (value) {
-        contentState = Modifier.removeInlineStyle(
-          contentState,
-          editorState.getSelection(),
-          value
-        );
+        contentState = Modifier.removeInlineStyle(contentState, editorState.getSelection(), value);
       }
-    })
+    });
 
     return EditorState.push(editorState, contentState, 'change-inline-style');
   };
@@ -71,7 +68,7 @@ export default class Remove extends Component {
       expanded: this.signalExpanded,
     });
     this.signalExpanded = false;
-  }
+  };
 
   onExpandEvent: Function = (): void => {
     this.signalExpanded = !this.state.expanded;

--- a/js/src/components/Controls/TextAlign/Component/index.js
+++ b/js/src/components/Controls/TextAlign/Component/index.js
@@ -1,6 +1,7 @@
 /* @flow */
 
-import React, { Component, PropTypes } from 'react';
+import React, { Component } from 'react';
+import PropTypes from 'prop-types';
 import classNames from 'classnames';
 
 import Option from '../../../Option';
@@ -9,7 +10,6 @@ import { getFirstIcon } from '../../../../utils/toolbar';
 import styles from './styles.css'; // eslint-disable-line no-unused-vars
 
 export default class TextAlign extends Component {
-
   static propTypes = {
     expanded: PropTypes.bool,
     doExpand: PropTypes.func,
@@ -21,53 +21,52 @@ export default class TextAlign extends Component {
   };
 
   renderInFlatList(): Object {
-    const { config: { options, left, center, right, justify, className }, onChange, currentState: { textAlignment }} = this.props;
+    const {
+      config: { options, left, center, right, justify, className },
+      onChange,
+      currentState: { textAlignment },
+    } = this.props;
     return (
-      <div className={classNames('rdw-text-align-wrapper', className)} aria-label="rdw-textalign-control">
-        {options.indexOf('left') >= 0 && <Option
-          value="left"
-          className={classNames(left.className)}
-          active={textAlignment === 'left'}
-          onClick={onChange}
-        >
-          <img
-            src={left.icon}
-            alt=""
-          />
-        </Option>}
-        {options.indexOf('center') >= 0 && <Option
-          value="center"
-          className={classNames(center.className)}
-          active={textAlignment === 'center'}
-          onClick={onChange}
-        >
-          <img
-            src={center.icon}
-            alt=""
-          />
-        </Option>}
-        {options.indexOf('right') >= 0 && <Option
-          value="right"
-          className={classNames(right.className)}
-          active={textAlignment === 'right'}
-          onClick={onChange}
-        >
-          <img
-            src={right.icon}
-            alt=""
-          />
-        </Option>}
-        {options.indexOf('justify') >= 0 && <Option
-          value="justify"
-          className={classNames(justify.className)}
-          active={textAlignment === 'justify'}
-          onClick={onChange}
-        >
-          <img
-            src={justify.icon}
-            alt=""
-          />
-        </Option>}
+      <div
+        className={classNames('rdw-text-align-wrapper', className)}
+        aria-label="rdw-textalign-control"
+      >
+        {options.indexOf('left') >= 0 &&
+          <Option
+            value="left"
+            className={classNames(left.className)}
+            active={textAlignment === 'left'}
+            onClick={onChange}
+          >
+            <img src={left.icon} alt="" />
+          </Option>}
+        {options.indexOf('center') >= 0 &&
+          <Option
+            value="center"
+            className={classNames(center.className)}
+            active={textAlignment === 'center'}
+            onClick={onChange}
+          >
+            <img src={center.icon} alt="" />
+          </Option>}
+        {options.indexOf('right') >= 0 &&
+          <Option
+            value="right"
+            className={classNames(right.className)}
+            active={textAlignment === 'right'}
+            onClick={onChange}
+          >
+            <img src={right.icon} alt="" />
+          </Option>}
+        {options.indexOf('justify') >= 0 &&
+          <Option
+            value="justify"
+            className={classNames(justify.className)}
+            active={textAlignment === 'justify'}
+            onClick={onChange}
+          >
+            <img src={justify.icon} alt="" />
+          </Option>}
       </div>
     );
   }
@@ -94,50 +93,39 @@ export default class TextAlign extends Component {
         onExpandEvent={onExpandEvent}
         aria-label="rdw-textalign-control"
       >
-        <img
-          src={getFirstIcon(config)}
-          alt=""
-        />
-        {options.indexOf('left') >= 0 && <DropdownOption
-          value="left"
-          active={textAlignment === 'left'}
-          className={classNames('rdw-text-align-dropdownOption', left.className)}
-        >
-          <img
-            src={left.icon}
-            alt=""
-          />
-        </DropdownOption>}
-        {options.indexOf('center') >= 0 && <DropdownOption
-          value="center"
-          active={textAlignment === 'center'}
-          className={classNames('rdw-text-align-dropdownOption', center.className)}
-        >
-          <img
-            src={center.icon}
-            alt=""
-          />
-        </DropdownOption>}
-        {options.indexOf('right') >= 0 && <DropdownOption
-          value="right"
-          active={textAlignment === 'right'}
-          className={classNames('rdw-text-align-dropdownOption', right.className)}
-        >
-          <img
-            src={right.icon}
-            alt=""
-          />
-        </DropdownOption>}
-        {options.indexOf('justify') >= 0 && <DropdownOption
-          value="justify"
-          active={textAlignment === 'justify'}
-          className={classNames('rdw-text-align-dropdownOption', justify.className)}
-        >
-          <img
-            src={justify.icon}
-            alt=""
-          />
-        </DropdownOption>}
+        <img src={getFirstIcon(config)} alt="" />
+        {options.indexOf('left') >= 0 &&
+          <DropdownOption
+            value="left"
+            active={textAlignment === 'left'}
+            className={classNames('rdw-text-align-dropdownOption', left.className)}
+          >
+            <img src={left.icon} alt="" />
+          </DropdownOption>}
+        {options.indexOf('center') >= 0 &&
+          <DropdownOption
+            value="center"
+            active={textAlignment === 'center'}
+            className={classNames('rdw-text-align-dropdownOption', center.className)}
+          >
+            <img src={center.icon} alt="" />
+          </DropdownOption>}
+        {options.indexOf('right') >= 0 &&
+          <DropdownOption
+            value="right"
+            active={textAlignment === 'right'}
+            className={classNames('rdw-text-align-dropdownOption', right.className)}
+          >
+            <img src={right.icon} alt="" />
+          </DropdownOption>}
+        {options.indexOf('justify') >= 0 &&
+          <DropdownOption
+            value="justify"
+            active={textAlignment === 'justify'}
+            className={classNames('rdw-text-align-dropdownOption', justify.className)}
+          >
+            <img src={justify.icon} alt="" />
+          </DropdownOption>}
       </Dropdown>
     );
   }

--- a/js/src/components/Controls/TextAlign/index.js
+++ b/js/src/components/Controls/TextAlign/index.js
@@ -1,12 +1,12 @@
 /* @flow */
 
-import React, { Component, PropTypes } from 'react';
+import React, { Component } from 'react';
+import PropTypes from 'prop-types';
 import { getSelectedBlocksMetadata, setBlockData } from 'draftjs-utils';
 
 import LayoutComponent from './Component';
 
 export default class TextAlign extends Component {
-
   static propTypes = {
     editorState: PropTypes.object.isRequired,
     onChange: PropTypes.func.isRequired,
@@ -16,7 +16,7 @@ export default class TextAlign extends Component {
 
   state = {
     currentTextAlignment: undefined,
-  }
+  };
 
   componentWillMount(): void {
     const { modalHandler } = this.props;
@@ -41,7 +41,7 @@ export default class TextAlign extends Component {
       expanded: this.signalExpanded,
     });
     this.signalExpanded = false;
-  }
+  };
 
   onExpandEvent: Function = (): void => {
     this.signalExpanded = !this.state.expanded;
@@ -59,7 +59,7 @@ export default class TextAlign extends Component {
     });
   };
 
-  addBlockAlignmentData:Function = (value: string) => {
+  addBlockAlignmentData: Function = (value: string) => {
     const { editorState, onChange } = this.props;
     const { currentTextAlignment } = this.state;
     if (currentTextAlignment !== value) {
@@ -67,11 +67,11 @@ export default class TextAlign extends Component {
     } else {
       onChange(setBlockData(editorState, { 'text-align': undefined }));
     }
-  }
+  };
 
   render(): Object {
     const { config } = this.props;
-    const { expanded, currentTextAlignment } = this.state
+    const { expanded, currentTextAlignment } = this.state;
     const TextAlignmentComponent = config.component || LayoutComponent;
     return (
       <TextAlignmentComponent

--- a/js/src/components/Dropdown/Dropdown/index.js
+++ b/js/src/components/Dropdown/Dropdown/index.js
@@ -1,13 +1,13 @@
 /* @flow */
 
-import React, { Component, PropTypes } from 'react';
+import React, { Component } from 'react';
+import PropTypes from 'prop-types';
 import classNames from 'classnames';
 import styles from './styles.css'; // eslint-disable-line no-unused-vars
 
 import { stopPropagation } from '../../../utils/common';
 
 export default class Dropdown extends Component {
-
   static propTypes = {
     children: PropTypes.any,
     onChange: PropTypes.func,
@@ -72,10 +72,7 @@ export default class Dropdown extends Component {
         aria-expanded={expanded}
         aria-label={ariaLabel || 'rdw-dropdown'}
       >
-        <a
-          className="rdw-dropdown-selectedtext"
-          onClick={onExpandEvent}
-        >
+        <a className="rdw-dropdown-selectedtext" onClick={onExpandEvent}>
           {children[0]}
           <div
             className={classNames({
@@ -84,58 +81,57 @@ export default class Dropdown extends Component {
             })}
           />
         </a>
-        {expanded ?
-          <ul
+        {expanded
+          ? <ul
             className={classNames('rdw-dropdown-optionwrapper', optionWrapperClassName)}
             onClick={stopPropagation}
           >
-            {
-              React.Children.map(options, (option, index) => {
-                const temp = option && React.cloneElement(
-                  option, {
+            {React.Children.map(options, (option, index) => {
+              const temp =
+                  option &&
+                  React.cloneElement(option, {
                     onSelect: this.onChange,
                     highlighted: highlighted === index,
                     setHighlighted: this.setHighlighted,
                     index,
                   });
-                return temp;
-              })
-            }
-          </ul> : undefined}
+              return temp;
+            })}
+          </ul>
+          : undefined}
       </div>
     );
   }
 }
 
-
-  // onKeyDown: Function = (event: Object): void => {
-  //   const { expanded, children, doCollapse } = this.props;
-  //   const { highlighted } = this.state;
-  //   let actioned = false;
-  //   if (event.key === 'ArrowDown' || event.key === 'ArrowRight') {
-  //     if (!expanded) {
-  //       this.toggleExpansion();
-  //       actioned = true;
-  //     } else {
-  //       this.setHighlighted((highlighted === children[1].length - 1) ? 0 : highlighted + 1);
-  //       actioned = true;
-  //     }
-  //   } else if (event.key === 'ArrowUp' || event.key === 'ArrowLeft') {
-  //     this.setHighlighted(highlighted <= 0 ? children[1].length - 1 : highlighted - 1);
-  //     actioned = true;
-  //   } else if (event.key === 'Enter') {
-  //     if (highlighted > -1) {
-  //       this.onChange(this.props.children[1][highlighted].props.value);
-  //       actioned = true;
-  //     } else {
-  //       this.toggleExpansion();
-  //       actioned = true;
-  //     }
-  //   } else if (event.key === 'Escape') {
-  //     doCollapse();
-  //     actioned = true;
-  //   }
-  //   if (actioned) {
-  //     event.preventDefault();
-  //   }
-  // };
+// onKeyDown: Function = (event: Object): void => {
+//   const { expanded, children, doCollapse } = this.props;
+//   const { highlighted } = this.state;
+//   let actioned = false;
+//   if (event.key === 'ArrowDown' || event.key === 'ArrowRight') {
+//     if (!expanded) {
+//       this.toggleExpansion();
+//       actioned = true;
+//     } else {
+//       this.setHighlighted((highlighted === children[1].length - 1) ? 0 : highlighted + 1);
+//       actioned = true;
+//     }
+//   } else if (event.key === 'ArrowUp' || event.key === 'ArrowLeft') {
+//     this.setHighlighted(highlighted <= 0 ? children[1].length - 1 : highlighted - 1);
+//     actioned = true;
+//   } else if (event.key === 'Enter') {
+//     if (highlighted > -1) {
+//       this.onChange(this.props.children[1][highlighted].props.value);
+//       actioned = true;
+//     } else {
+//       this.toggleExpansion();
+//       actioned = true;
+//     }
+//   } else if (event.key === 'Escape') {
+//     doCollapse();
+//     actioned = true;
+//   }
+//   if (actioned) {
+//     event.preventDefault();
+//   }
+// };

--- a/js/src/components/Dropdown/DropdownOption/index.js
+++ b/js/src/components/Dropdown/DropdownOption/index.js
@@ -1,11 +1,11 @@
 /* @flow */
 
-import React, { Component, PropTypes } from 'react';
+import React, { Component } from 'react';
+import PropTypes from 'prop-types';
 import classNames from 'classnames';
 import styles from './styles.css'; // eslint-disable-line no-unused-vars
 
 export default class DropDownOption extends Component {
-
   static propTypes = {
     children: PropTypes.any,
     value: PropTypes.any,
@@ -55,17 +55,14 @@ export default class DropDownOption extends Component {
       activeClassName,
       disabledClassName,
       highlightedClassName,
-     } = this.props;
+    } = this.props;
     return (
       <li
-        className={classNames(
-            'rdw-dropdownoption-default',
-            className,
-            { [`rdw-dropdownoption-active ${activeClassName}`]: active,
-              [`rdw-dropdownoption-highlighted ${highlightedClassName}`]: highlighted,
-              [`rdw-dropdownoption-disabled ${disabledClassName}`]: disabled,
-            })
-        }
+        className={classNames('rdw-dropdownoption-default', className, {
+          [`rdw-dropdownoption-active ${activeClassName}`]: active,
+          [`rdw-dropdownoption-highlighted ${highlightedClassName}`]: highlighted,
+          [`rdw-dropdownoption-disabled ${disabledClassName}`]: disabled,
+        })}
         onMouseEnter={this.setHighlighted}
         onMouseLeave={this.resetHighlighted}
         onClick={this.onClick}

--- a/js/src/components/Editor/index.js
+++ b/js/src/components/Editor/index.js
@@ -1,6 +1,7 @@
 /* @flow */
 
-import React, { Component, PropTypes } from 'react';
+import React, { Component } from 'react';
+import PropTypes from 'prop-types';
 import {
   Editor,
   EditorState,

--- a/js/src/components/Option/index.js
+++ b/js/src/components/Option/index.js
@@ -1,11 +1,11 @@
 /* @flow */
 
-import React, { Component, PropTypes } from 'react';
+import React, { Component } from 'react';
+import PropTypes from 'prop-types';
 import classNames from 'classnames';
 import styles from './styles.css'; // eslint-disable-line no-unused-vars
 
 export default class Option extends Component {
-
   static propTypes = {
     onClick: PropTypes.func.isRequired,
     children: PropTypes.any,
@@ -27,14 +27,10 @@ export default class Option extends Component {
     const { children, className, activeClassName, active, disabled } = this.props;
     return (
       <div
-        className={classNames(
-          'rdw-option-wrapper',
-          className,
-          {
-            [`rdw-option-active ${activeClassName}`]: active,
-            'rdw-option-disabled': disabled,
-          }
-        )}
+        className={classNames('rdw-option-wrapper', className, {
+          [`rdw-option-active ${activeClassName}`]: active,
+          'rdw-option-disabled': disabled,
+        })}
         onClick={this.onClick}
         aria-selected={active}
       >

--- a/js/src/decorators/HashTag/index.js
+++ b/js/src/decorators/HashTag/index.js
@@ -1,10 +1,10 @@
-import React, { PropTypes, Component } from 'react';
+import React, { Component } from 'react';
+import PropTypes from 'prop-types';
 import { Entity } from 'draft-js';
 import classNames from 'classnames';
 import styles from './styles.css'; // eslint-disable-line no-unused-vars
 
 class Hashtag {
-
   constructor(config) {
     this.className = config.className;
     this.hashCharacter = config.hashCharacter || '#';
@@ -16,7 +16,7 @@ class Hashtag {
     return class HashtagComponent extends Component {
       static PropTypes = {
         children: PropTypes.object,
-      }
+      };
       render() {
         const { children } = this.props;
         const text = children[0].props.text;
@@ -34,7 +34,7 @@ class Hashtag {
     let startIndex = 0;
     let counter = 0;
 
-    for (;text.length > 0 && startIndex >= 0;) {
+    for (; text.length > 0 && startIndex >= 0;) {
       if (text[0] === this.hashCharacter) {
         startIndex = 0;
         counter = 0;
@@ -47,8 +47,9 @@ class Hashtag {
         }
       }
       if (startIndex >= 0) {
-        const endIndex =
-          text.indexOf(this.separator) >= 0 ? text.indexOf(this.separator) : text.length;
+        const endIndex = text.indexOf(this.separator) >= 0
+          ? text.indexOf(this.separator)
+          : text.length;
         const hashtagText = text.substr(0, endIndex);
         if (hashtagText && hashtagText.length > 0) {
           callback(counter, counter + hashtagText.length + this.hashCharacter.length);
@@ -58,14 +59,12 @@ class Hashtag {
     }
   };
 
-  getHashtagDecorator = () => {
-    return {
-      strategy: this.findHashtagEntities,
-      component: this.getHashtagComponent(),
-    }
-  };
+  getHashtagDecorator = () => ({
+    strategy: this.findHashtagEntities,
+    component: this.getHashtagComponent(),
+  });
 }
 
-const getDecorator = (config) => (new Hashtag(config)).getHashtagDecorator();
+const getDecorator = config => new Hashtag(config).getHashtagDecorator();
 
 module.exports = getDecorator;

--- a/js/src/decorators/Mention/Mention/index.js
+++ b/js/src/decorators/Mention/Mention/index.js
@@ -1,4 +1,5 @@
-import React, { PropTypes, Component } from 'react';
+import React, { Component } from 'react';
+import PropTypes from 'prop-types';
 import { Entity } from 'draft-js';
 import classNames from 'classnames';
 import styles from './styles.css'; // eslint-disable-line no-unused-vars
@@ -14,7 +15,7 @@ class Mention {
         entityKey: PropTypes.number,
         children: PropTypes.object,
         contentState: PropTypes.object,
-      }
+      };
       render() {
         const { entityKey, children, contentState } = this.props;
         const { url, value } = contentState.getEntity(entityKey).getData();
@@ -26,25 +27,17 @@ class Mention {
       }
     };
   };
-  getMentionDecorator = () => {
-    return {
-      strategy: this.findMentionEntities,
-      component: this.getMentionComponent(),
-    }
-  };
+  getMentionDecorator = () => ({
+    strategy: this.findMentionEntities,
+    component: this.getMentionComponent(),
+  });
 }
 
 Mention.prototype.findMentionEntities = (contentBlock, callback, contentState) => {
-  contentBlock.findEntityRanges(
-    (character) => {
-      const entityKey = character.getEntity();
-      return (
-        entityKey !== null &&
-        contentState.getEntity(entityKey).getType() === 'MENTION'
-      );
-    },
-    callback,
-  );
+  contentBlock.findEntityRanges((character) => {
+    const entityKey = character.getEntity();
+    return entityKey !== null && contentState.getEntity(entityKey).getType() === 'MENTION';
+  }, callback);
 };
 
 module.exports = Mention;

--- a/js/src/decorators/Mention/Suggestion/index.js
+++ b/js/src/decorators/Mention/Suggestion/index.js
@@ -1,4 +1,5 @@
-import React, { PropTypes, Component } from 'react';
+import React, { Component } from 'react';
+import PropTypes from 'prop-types';
 import classNames from 'classnames';
 import addMention from '../addMention';
 import KeyDownHandler from '../../../event-handler/keyDown';
@@ -37,14 +38,16 @@ class Suggestion {
     if (this.config.getEditorState()) {
       const { separator, trigger, getSuggestions, getEditorState } = this.config;
       const selection = getEditorState().getSelection();
-      if (selection.get('anchorKey') === contentBlock.get('key') &&
-        selection.get('anchorKey') === selection.get('focusKey')) {
+      if (
+        selection.get('anchorKey') === contentBlock.get('key') &&
+        selection.get('anchorKey') === selection.get('focusKey')
+      ) {
         let text = contentBlock.getText();
         text = text.substr(
           0,
           selection.get('focusOffset') === text.length - 1
-          ? text.length
-          : selection.get('focusOffset') + 1
+            ? text.length
+            : selection.get('focusOffset') + 1,
         );
         let index = text.lastIndexOf(separator + trigger);
         let preText = separator + trigger;
@@ -54,14 +57,16 @@ class Suggestion {
         }
         if (index >= 0) {
           const mentionText = text.substr(index + preText.length, text.length);
-          const suggestionPresent =
-          getSuggestions().some((suggestion) => {
+          const suggestionPresent = getSuggestions().some((suggestion) => {
             if (suggestion.value) {
               if (this.config.caseSensitive) {
                 return suggestion.value.indexOf(mentionText) >= 0;
-              } else {
-                return suggestion.value.toLowerCase().indexOf(mentionText && mentionText.toLowerCase()) >= 0;
               }
+              return (
+                  suggestion.value
+                    .toLowerCase()
+                    .indexOf(mentionText && mentionText.toLowerCase()) >= 0
+              );
             }
           });
           if (suggestionPresent) {
@@ -70,22 +75,19 @@ class Suggestion {
         }
       }
     }
-  }
+  };
 
   getSuggestionComponent = getSuggestionComponent.bind(this);
 
-  getSuggestionDecorator = () => {
-    return {
-      strategy: this.findSuggestionEntities,
-      component: this.getSuggestionComponent(),
-    }
-  };
+  getSuggestionDecorator = () => ({
+    strategy: this.findSuggestionEntities,
+    component: this.getSuggestionComponent(),
+  });
 }
 
 function getSuggestionComponent() {
   const { config } = this;
   return class SuggestionComponent extends Component {
-
     static propTypes = {
       children: PropTypes.array,
     };
@@ -103,7 +105,7 @@ function getSuggestionComponent() {
       let left;
       let right;
       let bottom;
-      if (editorRect.width < (suggestionRect.left - editorRect.left) + dropdownRect.width) {
+      if (editorRect.width < suggestionRect.left - editorRect.left + dropdownRect.width) {
         right = 15;
       } else {
         left = 15;
@@ -111,7 +113,8 @@ function getSuggestionComponent() {
       if (editorRect.bottom < dropdownRect.bottom) {
         bottom = 0;
       }
-      this.setState({ // eslint-disable-line react/no-did-mount-set-state
+      this.setState({
+        // eslint-disable-line react/no-did-mount-set-state
         style: { left, right, bottom },
       });
       KeyDownHandler.registerCallBack(this.onEditorKeyDown);
@@ -158,19 +161,19 @@ function getSuggestionComponent() {
         this.addMention();
       }
       this.setState(newState);
-    }
+    };
 
     onOptionMouseEnter = (index) => {
       this.setState({
         activeOption: index,
       });
-    }
+    };
 
     onOptionMouseLeave = () => {
       this.setState({
         activeOption: -1,
       });
-    }
+    };
 
     setSuggestionReference: Function = (ref: Object): void => {
       this.suggestion = ref;
@@ -184,7 +187,7 @@ function getSuggestionComponent() {
       this.setState({
         showSuggestions: false,
       });
-    }
+    };
 
     filteredSuggestions = [];
 
@@ -192,24 +195,26 @@ function getSuggestionComponent() {
       const mentionText = props.children[0].props.text.substr(1);
       const suggestions = config.getSuggestions();
       this.filteredSuggestions =
-        suggestions && suggestions.filter((suggestion) => {
+        suggestions &&
+        suggestions.filter((suggestion) => {
           if (!mentionText || mentionText.length === 0) {
             return true;
           }
           if (config.caseSensitive) {
             return suggestion.value.indexOf(mentionText) >= 0;
-          } else {
-            return suggestion.value.toLowerCase().indexOf(mentionText && mentionText.toLowerCase()) >= 0;
           }
+          return (
+              suggestion.value.toLowerCase().indexOf(mentionText && mentionText.toLowerCase()) >= 0
+          );
         });
-    }
+    };
 
     addMention = () => {
       const { activeOption } = this.state;
       const editorState = config.getEditorState();
       const { onChange, separator, trigger } = config;
       addMention(editorState, onChange, separator, trigger, this.filteredSuggestions[activeOption]);
-    }
+    };
 
     render() {
       const { children } = this.props;
@@ -231,26 +236,25 @@ function getSuggestionComponent() {
               style={this.state.style}
               ref={this.setDropdownReference}
             >
-              {this.filteredSuggestions.map((suggestion, index) =>
+              {this.filteredSuggestions.map((suggestion, index) => (
                 <span
                   key={index}
                   spellCheck={false}
                   onClick={this.addMention}
                   onMouseEnter={this.onOptionMouseEnter.bind(this, index)}
                   onMouseLeave={this.onOptionMouseLeave}
-                  className={classNames(
-                    'rdw-suggestion-option',
-                    optionClassName,
-                    { 'rdw-suggestion-option-active': (index === activeOption) }
-                  )}
+                  className={classNames('rdw-suggestion-option', optionClassName, {
+                    'rdw-suggestion-option-active': index === activeOption,
+                  })}
                 >
                   {suggestion.text}
-                </span>)}
+                </span>
+              ))}
             </span>}
         </span>
       );
     }
-  }
+  };
 }
 
 module.exports = Suggestion;

--- a/js/src/renderer/Embedded/index.js
+++ b/js/src/renderer/Embedded/index.js
@@ -1,9 +1,10 @@
-import React, { PropTypes } from 'react';
+import React from 'react';
+import PropTypes from 'prop-types';
 
 const Embed = ({ block, contentState }) => {
   const entity = contentState.getEntity(block.getEntityAt(0));
   const { src, height, width } = entity.getData();
-  return (<iframe height={height} width={width} src={src} frameBorder="0" allowFullScreen />);
+  return <iframe height={height} width={width} src={src} frameBorder="0" allowFullScreen />;
 };
 
 Embed.propTypes = {

--- a/package.json
+++ b/package.json
@@ -54,8 +54,9 @@
   },
   "dependencies": {
     "classnames": "^2.2.5",
+    "draftjs-utils": "^0.7.3",
     "immutable": "^4.0.0-rc.1",
-    "draftjs-utils": "^0.7.3"
+    "prop-types": "^15.5.8"
   },
   "peerDependencies": {
     "draft-js": "^0.10.x",


### PR DESCRIPTION
Accessing PropTypes via the main React package is deprecated. I have added prop-types to the package dependencies and replaced all instances where PropTypes was accessed through the React package. 