### PR TITLE
Fix bad performance when open file dialog in chrome

### DIFF
--- a/js/src/components/Controls/Image/Component/index.js
+++ b/js/src/components/Controls/Image/Component/index.js
@@ -194,7 +194,7 @@ class LayoutComponent extends Component {
               <input
                 type="file"
                 id="file"
-                accept="image/*"
+                accept="image/gif,image/jpeg,image/jpg,image/png,image/svg"
                 onChange={this.selectImage}
                 className="rdw-image-modal-upload-option-input"
               />


### PR DESCRIPTION
It's very slow when open file dialog in chrome, usually takes 6-10s, change `accept="image/*"` to the specific image mime type will fix this.