### PR TITLE
Add wrapperId as prop

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,8 @@
+sudo: false
+os:
+  - osx
+language: node_js
+node_js:
+  - "7"
+script:
+  - npm test

--- a/js/src/components/Editor/index.js
+++ b/js/src/components/Editor/index.js
@@ -74,12 +74,14 @@ export default class WysiwygEditor extends Component {
     ariaExpanded: PropTypes.string,
     ariaHasPopup: PropTypes.string,
     customBlockRenderFunc: PropTypes.func,
+    wrapperId: PropTypes.string,
   };
 
   static defaultProps = {
     toolbarOnFocus: false,
     stripPastedStyles: false,
-  }
+    wrapperId: Math.floor(Math.random() * 10000),
+  };
 
   constructor(props) {
     super(props);
@@ -92,7 +94,7 @@ export default class WysiwygEditor extends Component {
       editorFocused: false,
       toolbar,
     };
-    this.wrapperId = `rdw-wrapper${Math.floor(Math.random() * 10000)}`;
+    this.wrapperId = `rdw-wrapper-${props.wrapperId}`;
     this.modalHandler = new ModalHandler();
     this.focusHandler = new FocusHandler();
     this.blockRendererFn = getBlockRenderFunc({ isReadOnly: this.isReadOnly }, props.customBlockRenderFunc);
@@ -201,7 +203,7 @@ export default class WysiwygEditor extends Component {
     const { readOnly, onEditorStateChange } = this.props;
     if (!readOnly) {
       if (onEditorStateChange) {
-        onEditorStateChange(editorState);
+        onEditorStateChange(editorState, this.props.wrapperId);
       }
       if (!hasProperty(this.props, 'editorState')) {
         this.setState({ editorState }, this.afterChange(editorState));


### PR DESCRIPTION
- Randomly generated `wrapperId` breaks server rendering
- Passing wrapper id to `onEditorStateChange` callback makes creating multiple editors easier. 

Consider the following:

```
class MyComponent extends React.Component {

  constructor(props) {
    super(props);
    this.state = {};
    this.editors = ['notes', 'content', 'foo', 'bar'];
    this.editors.forEach((editorId) => {
      this.state[`editor-${editorId}`] = '<p></p>';
    });
    this.onEditorChange.bind(this);
  }

  makeEditor(id = '', state) {
    return (
      <Editor
        wrapperId={id}
        onEditorStateChange={this.onEditorChange}
        editorState={state}
      />
    );
  }

  onEditorChange(editorState, id) {
    this.setState({
      [`editor-${id}`]: editorState
    });
  }

  render() {
    return (
      this.editors
        .map(editorId => this.makeEditor(editorId, this.state[`editor-${editorId}`]))
    );
  }
}
```