### PR TITLE
set box-sizing style

### DIFF
--- a/js/src/components/Editor/styles.css
+++ b/js/src/components/Editor/styles.css
@@ -23,3 +23,6 @@
 .rdw-editor-wrapper:focus {
   outline: none;
 }
+.rdw-editor-wrapper {
+  box-sizing: content-box;
+}


### PR DESCRIPTION
As all the width and height are set by content-box, if we introduce some style framework like bootstrap which reset box-sizing to border-box, the styles of this editor (especially the toolbar) will corrupt.