### PR TITLE
fix width bug

### DIFF
--- a/js/src/components/Editor/styles.css
+++ b/js/src/components/Editor/styles.css
@@ -1,6 +1,5 @@
 .rdw-editor-main {
   height: 100%;
-  width: 100%;
   overflow: auto;
   box-sizing: border-box;
 }
@@ -10,7 +9,6 @@
   border: 1px solid #F1F1F1;
   display: flex;
   justify-content: flex-start;
-  width: 100%;
   background: white;
   flex-wrap: wrap;
   font-size: 15px;


### PR DESCRIPTION
I notice the a width bug:
![image](https://cloud.githubusercontent.com/assets/3808838/26363347/540dfe90-4013-11e7-8812-4c27b5a5ebd4.png)
according to this post
https://stackoverflow.com/questions/17468733/difference-between-width-auto-and-width-100-percent
we should not set width: 100%, but width: auto instead.