### PR TITLE
added missing import in example code in readme file.

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ The package can be installed from npm `react-draft-wysiwyg`
 ## Getting started
 Editor can be used as simple React Component:
 ```js
-import { Editor } from 'react-draft-wysiwyg';
+import { Editor, editorState } from 'react-draft-wysiwyg';
 import 'react-draft-wysiwyg/dist/react-draft-wysiwyg.css';
 <Editor
   editorState={editorState}


### PR DESCRIPTION
editorState was missing from the example readme import statement.So i have added it.