### PR TITLE
Limit pre and blockquote styles to only within the wysiwyg

### DIFF
--- a/src/Editor/styles.css
+++ b/src/Editor/styles.css
@@ -24,11 +24,11 @@
 .rdw-editor-wrapper {
   box-sizing: content-box;
 }
-blockquote {
+.rdw-editor-main blockquote {
   border-left: 5px solid #f1f1f1;
   padding-left: 5px;
 }
-pre {
+.rdw-editor-main pre {
   background: #f1f1f1;
   border-radius: 3px;
   padding: 1px 10px;


### PR DESCRIPTION
Recent changes in commit c831168bae80d514daecd2536e65597fe6e2fd01 have polluted the styles for other `pre` and `blockquote` elements within our application. This pull request contains a change to limit the new styles to only be applied within the `rdw-editor-main` element.

This change assumes that the `pre` and `blockquote` would appear as descendants  of an element that uses the class name `rdw-editor-main`. I am not familiar enough with the project to know this is true with 100% confidence. But it seems correct.