### PR TITLE
Append px to image size if units are not explicitly provided

### DIFF
--- a/src/controls/Image/Component/index.js
+++ b/src/controls/Image/Component/index.js
@@ -87,8 +87,15 @@ class LayoutComponent extends Component {
   };
 
   addImageFromState: Function = (): void => {
-    const { imgSrc, height, width, alt } = this.state;
+    const { imgSrc, alt } = this.state;
+    let { height, width } = this.state;
     const { onChange } = this.props;
+    if (!isNaN(height)) {
+      height += 'px';
+    }
+    if (!isNaN(width)) {
+      width += 'px';
+    }
     onChange(imgSrc, height, width, alt);
   };
 


### PR DESCRIPTION
When an image is added if you provide only numbers for height and width ( without units ) it won't work once you save the html and show it later.
Also a warning is shown in the console:
![error](https://user-images.githubusercontent.com/2043833/31075349-58d56f48-a775-11e7-97cf-e17a8a0ef73e.jpg)

This fix handles that by automatically appending "px" to the number if no unit is specified.