### PR TITLE
Check if the selected mention is valid

### DIFF
--- a/src/decorators/Mention/Suggestion/index.js
+++ b/src/decorators/Mention/Suggestion/index.js
@@ -208,7 +208,10 @@ function getSuggestionComponent() {
       const { activeOption } = this.state;
       const editorState = config.getEditorState();
       const { onChange, separator, trigger } = config;
-      addMention(editorState, onChange, separator, trigger, this.filteredSuggestions[activeOption]);
+      const selectedMention = this.filteredSuggestions[activeOption];
+      if(selectedMention) {
+        addMention(editorState, onChange, separator, trigger, selectedMention);
+      }
     }
 
     render() {


### PR DESCRIPTION
This is the proposed fix for #480.

Currently if a user presses 'Enter' when the mentions dropdown is showing, but has not selected an option, an error will be thrown. This first checks if there is a mention selected before it tries to add it.