### PR TITLE
Fixing adding mentions

### DIFF
--- a/src/decorators/Mention/Suggestion/index.js
+++ b/src/decorators/Mention/Suggestion/index.js
@@ -209,7 +209,7 @@ function getSuggestionComponent() {
       const editorState = config.getEditorState();
       const { onChange, separator, trigger } = config;
       const selectedMention = this.filteredSuggestions[activeOption];
-      if(selectedMention) {
+      if (selectedMention) {
         addMention(editorState, onChange, separator, trigger, selectedMention);
       }
     }

--- a/src/decorators/Mention/addMention.js
+++ b/src/decorators/Mention/addMention.js
@@ -18,13 +18,11 @@ export default function addMention(
     .getLastCreatedEntityKey();
   const selectedBlock = getSelectedBlock(editorState);
   const selectedBlockText = selectedBlock.getText();
-  const mentionIndex = (selectedBlockText.lastIndexOf(separator + trigger) || 0) + 1;
-  let focusOffset;
+  let focusOffset = editorState.getSelection().focusOffset;
+  const mentionIndex = (selectedBlockText.lastIndexOf(separator + trigger, focusOffset) || 0) + 1;
   let spaceAlreadyPresent = false;
   if (selectedBlockText.length === mentionIndex + 1) {
     focusOffset = selectedBlockText.length;
-  } else {
-    focusOffset = editorState.getSelection().focusOffset;
   }
   if (selectedBlockText[focusOffset] === ' ') {
     spaceAlreadyPresent = true;


### PR DESCRIPTION
Currently if you try to add a mention before a mention that you have already added previously, it does some weird things.

This PR just makes sure that you find the correct offset for the mention, no matter where you decide to put that mention.

## Example:
First I write this:
`This is an @apple`

Then I decide to add another one:
`This is a @bana and an @apple`
Which brings up the mentions menu, I click on the BANANA option, and this happens:

`This is a @bana and an @banana and an @apple`