### PR TITLE
Fix content editable warning for mentions

### DIFF
--- a/src/decorators/Mention/Suggestion/index.js
+++ b/src/decorators/Mention/Suggestion/index.js
@@ -231,6 +231,7 @@ function getSuggestionComponent() {
             <span
               className={classNames('rdw-suggestion-dropdown', dropdownClassName)}
               contentEditable="false"
+              suppressContentEditableWarning
               style={this.state.style}
               ref={this.setDropdownReference}
             >


### PR DESCRIPTION
Proposed fix for #86 

Currently a 
```
A component is `contentEditable` and contains `children` managed by React
```
warning comes up when you use mentions. Not a big deal, but very annoying when you have the console open. This PR suppresses those warnings.