### PR TITLE
Change "Background" to "Highlight"

### DIFF
--- a/src/i18n/en.js
+++ b/src/i18n/en.js
@@ -19,7 +19,7 @@ module.exports = {
   // Color Picker
   'components.controls.colorpicker.colorpicker': 'Color Picker',
   'components.controls.colorpicker.text': 'Text',
-  'components.controls.colorpicker.background': 'Background',
+  'components.controls.colorpicker.background': 'Highlight',
 
   // Embedded
   'components.controls.embedded.embedded': 'Embedded',


### PR DESCRIPTION
The word "Highlight" is better suited to English users. 

"Background" is the term used in HTML; however, a common English user would think that the background color would change the background of the entire editor instead of the chosen text. The word "Highlight" more accurately describes the effect of changing the background behind a line of text.