### PR TITLE
Change "Font Family" to "Font"

### DIFF
--- a/src/i18n/en.js
+++ b/src/i18n/en.js
@@ -30,7 +30,7 @@ module.exports = {
   'components.controls.emoji.emoji': 'Emoji',
 
   // FontFamily
-  'components.controls.fontfamily.fontfamily': 'Font Family',
+  'components.controls.fontfamily.fontfamily': 'Font',
 
   // FontSize
   'components.controls.fontsize.fontsize': 'Font Size',


### PR DESCRIPTION
A common English user would not recognize the terms "font family". Most English users refer simply to the "font".