### PR TITLE
fix(Link): Update link creation

### DIFF
--- a/src/controls/Link/index.js
+++ b/src/controls/Link/index.js
@@ -125,7 +125,7 @@ class Link extends Component {
     }
     const entityKey = editorState
       .getCurrentContent()
-      .createEntity('LINK', 'MUTABLE', { url: linkTarget, target: linkTargetOption })
+      .createEntity('LINK', 'MUTABLE', { url: linkTarget, targetOption: linkTargetOption })
       .getLastCreatedEntityKey();
 
     let contentState = Modifier.replaceText(


### PR DESCRIPTION
The correct key for a link `target`, such as `_blank` is `targetOption` instead of `target`

It looks like draft-js doesn't recognize the `target` key and ignores it when creating an `<a>` tag