### PR TITLE
Avoid error when an alignment is not defined. fixes #514

### DIFF
--- a/src/controls/TextAlign/Component/index.js
+++ b/src/controls/TextAlign/Component/index.js
@@ -107,7 +107,7 @@ export default class TextAlign extends Component {
         title={title || translations['components.controls.textalign.textalign']}
       >
         <img
-          src={(textAlignment && config[textAlignment].icon) || getFirstIcon(config)}
+          src={(textAlignment && config[textAlignment] && config[textAlignment].icon) || getFirstIcon(config)}
           alt=""
         />
         {options.indexOf('left') >= 0 && <DropdownOption


### PR DESCRIPTION
As suggested in https://github.com/jpuri/react-draft-wysiwyg/issues/514