### PR TITLE
Removed unused import

### DIFF
--- a/docs/src/components/Demo/EditorConvertToHTML/index.js
+++ b/docs/src/components/Demo/EditorConvertToHTML/index.js
@@ -49,7 +49,7 @@ class EditorConvertToHTML extends Component {
           <Codemirror
             value={
               'import React, { Component } from \'react\';\n' +
-              'import { EditorState, convertToRaw, ContentState } from \'draft-js\';\n' +
+              'import { EditorState, convertToRaw } from \'draft-js\';\n' +
               'import { Editor } from \'react-draft-wysiwyg\';\n' +
               'import draftToHtml from \'draftjs-to-html\';\n' +
               'import htmlToDraft from \'html-to-draftjs\';\n' +


### PR DESCRIPTION
There was an unused import in the first example at demo page. So I removed this one.