### PR TITLE
changed includes to indexOf for Array object

### DIFF
--- a/src/controls/BlockType/Component/index.js
+++ b/src/controls/BlockType/Component/index.js
@@ -113,7 +113,7 @@ class LayoutComponent extends Component {
     const { config } = this.props;
     const { inDropdown } = config;
     const { blockTypes } = this.state;
-    const blocks = blockTypes.filter(({ label }) => config.options.includes(label));
+    const blocks = blockTypes.filter(({ label }) => config.options.indexOf(label) > -1);
     return inDropdown ? this.renderInDropdown(blocks) : this.renderFlat(blocks);
   }
 }


### PR DESCRIPTION
This is to fix an issue when I was running mocha test for react-draft-wysiwyg. The idea is that the Array object in browsers always has includes() method. However if you run this in mocha or node, it will not be available. You have to enable the flag --harmony_array_includes. This can be done but the includes method can be replaced with indexOf() so that other developers do not have to google up for the issue.

https://github.com/nodejs/node/issues/5715