### PR TITLE
Use data.url for imageUpload response handling instead of just data.link

### DIFF
--- a/src/controls/Image/Component/index.js
+++ b/src/controls/Image/Component/index.js
@@ -132,7 +132,7 @@ class LayoutComponent extends Component {
         this.setState({
           showImageLoading: false,
           dragEnter: false,
-          imgSrc: data.link,
+          imgSrc: data.link || data.url,
         });
         this.fileUpload = false;
       }).catch(() => {


### PR DESCRIPTION
**What is the problem ?**
Some people might use cloudinary or other image upload services instead of imgur but their uploadCallback will fail on react-draft-wysiwyg because imageUpload assume the data reside at `data.link` instead of general `data.url`

**Comparison of popular image uploading api, assuming we use axios**
1. imgur (https://api.imgur.com/models/image)
uploaded image url is returned at `response.data.link`

2. cloudinary (https://cloudinary.com/documentation/upload_images#upload_response)
uploaded image url is returned at `response.data.secure_url` and `response.data.url`

**Proposed solution**
Fallback to `data.url` if `data.link` is not working. I think `url` is more general than `link` in API response
Cloudinary API for example, returns it in `data.url`
compared to Imgur API that returns it in `data.link` 

#653 