### PR TITLE
Prevent systematic setState call in controls on window.onclick

### DIFF
--- a/src/controls/BlockType/index.js
+++ b/src/controls/BlockType/index.js
@@ -50,9 +50,11 @@ class BlockType extends Component {
   };
 
   expandCollapse: Function = (): void => {
-    this.setState({
-      expanded: this.signalExpanded,
-    });
+    if (!!this.signalExpanded !== this.state.expanded) {
+      this.setState({
+        expanded: this.signalExpanded,
+      });
+    }
     this.signalExpanded = false;
   }
 

--- a/src/controls/ColorPicker/index.js
+++ b/src/controls/ColorPicker/index.js
@@ -57,9 +57,11 @@ class ColorPicker extends Component {
   };
 
   expandCollapse: Function = (): void => {
-    this.setState({
-      expanded: this.signalExpanded,
-    });
+    if (!!this.signalExpanded !== this.state.expanded) {
+      this.setState({
+        expanded: this.signalExpanded,
+      });
+    }
     this.signalExpanded = false;
   }
 

--- a/src/controls/Embedded/index.js
+++ b/src/controls/Embedded/index.js
@@ -34,9 +34,11 @@ class Embedded extends Component {
   };
 
   expandCollapse: Function = (): void => {
-    this.setState({
-      expanded: this.signalExpanded,
-    });
+    if (!!this.signalExpanded !== this.state.expanded) {
+      this.setState({
+        expanded: this.signalExpanded,
+      });
+    }
     this.signalExpanded = false;
   }
 

--- a/src/controls/Emoji/index.js
+++ b/src/controls/Emoji/index.js
@@ -34,9 +34,11 @@ export default class Emoji extends Component {
   };
 
   expandCollapse: Function = (): void => {
-    this.setState({
-      expanded: this.signalExpanded,
-    });
+    if (!!this.signalExpanded !== this.state.expanded) {
+      this.setState({
+        expanded: this.signalExpanded,
+      });
+    }
     this.signalExpanded = false;
   }
 

--- a/src/controls/FontFamily/index.js
+++ b/src/controls/FontFamily/index.js
@@ -53,9 +53,11 @@ export default class FontFamily extends Component {
   };
 
   expandCollapse: Function = (): void => {
-    this.setState({
-      expanded: this.signalExpanded,
-    });
+    if (!!this.signalExpanded !== this.state.expanded) {
+      this.setState({
+        expanded: this.signalExpanded,
+      });
+    }
     this.signalExpanded = false;
   }
 

--- a/src/controls/FontSize/index.js
+++ b/src/controls/FontSize/index.js
@@ -54,9 +54,11 @@ export default class FontSize extends Component {
   };
 
   expandCollapse: Function = (): void => {
-    this.setState({
-      expanded: this.signalExpanded,
-    });
+    if (!!this.signalExpanded !== this.state.expanded) {
+      this.setState({
+        expanded: this.signalExpanded,
+      });
+    }
     this.signalExpanded = false;
   }
 

--- a/src/controls/History/index.js
+++ b/src/controls/History/index.js
@@ -72,9 +72,11 @@ export default class History extends Component {
   };
 
   expandCollapse: Function = (): void => {
-    this.setState({
-      expanded: this.signalExpanded,
-    });
+    if (!!this.signalExpanded !== this.state.expanded) {
+      this.setState({
+        expanded: this.signalExpanded,
+      });
+    }
     this.signalExpanded = false;
   }
 

--- a/src/controls/Image/index.js
+++ b/src/controls/Image/index.js
@@ -46,9 +46,11 @@ class ImageControl extends Component {
   };
 
   expandCollapse: Function = (): void => {
-    this.setState({
-      expanded: this.signalExpanded,
-    });
+    if (!!this.signalExpanded !== this.state.expanded) {
+      this.setState({
+        expanded: this.signalExpanded,
+      });
+    }
     this.signalExpanded = false;
   }
 

--- a/src/controls/Inline/index.js
+++ b/src/controls/Inline/index.js
@@ -50,9 +50,11 @@ export default class Inline extends Component {
   };
 
   expandCollapse: Function = (): void => {
-    this.setState({
-      expanded: this.signalExpanded,
-    });
+    if (!!this.signalExpanded !== this.state.expanded) {
+      this.setState({
+        expanded: this.signalExpanded,
+      });
+    }
     this.signalExpanded = false;
   }
 

--- a/src/controls/Link/index.js
+++ b/src/controls/Link/index.js
@@ -90,9 +90,11 @@ class Link extends Component {
   };
 
   expandCollapse: Function = (): void => {
-    this.setState({
-      expanded: this.signalExpanded,
-    });
+    if (!!this.signalExpanded !== this.state.expanded) {
+      this.setState({
+        expanded: this.signalExpanded,
+      });
+    }
     this.signalExpanded = false;
   }
 

--- a/src/controls/List/index.js
+++ b/src/controls/List/index.js
@@ -59,9 +59,11 @@ export default class List extends Component {
   };
 
   expandCollapse: Function = (): void => {
-    this.setState({
-      expanded: this.signalExpanded,
-    });
+    if (!!this.signalExpanded !== this.state.expanded) {
+      this.setState({
+        expanded: this.signalExpanded,
+      });
+    }
     this.signalExpanded = false;
   }
 

--- a/src/controls/Remove/index.js
+++ b/src/controls/Remove/index.js
@@ -36,9 +36,11 @@ export default class Remove extends Component {
   };
 
   expandCollapse: Function = (): void => {
-    this.setState({
-      expanded: this.signalExpanded,
-    });
+    if (!!this.signalExpanded !== this.state.expanded) {
+      this.setState({
+        expanded: this.signalExpanded,
+      });
+    }
     this.signalExpanded = false;
   }
 

--- a/src/controls/TextAlign/index.js
+++ b/src/controls/TextAlign/index.js
@@ -42,9 +42,11 @@ export default class TextAlign extends Component {
   };
 
   expandCollapse: Function = (): void => {
-    this.setState({
-      expanded: this.signalExpanded,
-    });
+    if (!!this.signalExpanded !== this.state.expanded) {
+      this.setState({
+        expanded: this.signalExpanded,
+      });
+    }
     this.signalExpanded = false;
   }
 


### PR DESCRIPTION
I was playing around with the react extension component update highlighting to optimize my code and I noticed that the react-draft-wysiwyg was updating the toolbar controls on every window clicks.
I found that disturbing so here's the fix. This is very low priority.

NB: The double bang is because `signalExpended` is undefined on first call and we never want `expanded` to become undefined
