### PR TITLE
Removed double semicolon from image rendering css

### DIFF
--- a/src/renderer/Image/styles.css
+++ b/src/renderer/Image/styles.css
@@ -1,5 +1,5 @@
 .rdw-image-alignment-options-popup {
-  position: absolute;;
+  position: absolute;
   background: white;
   display: flex;
   padding: 5px 2px;


### PR DESCRIPTION
This double semicolon was causing issue in my build tooling, specifically https://github.com/zoobestik/csso-webpack-plugin . There is bugs in there to fix their parser but figure I would submit it here as a minor fix.