### PR TITLE
Removing customStyleMap class variable and calculation of customStyle from componentWillReceiveProps

### DIFF
--- a/src/Editor/index.js
+++ b/src/Editor/index.js
@@ -117,7 +117,6 @@ export default class WysiwygEditor extends Component {
       props.customBlockRenderFunc
     );
     this.editorProps = this.filterEditorProps(props);
-    this.customStyleMap = getCustomStyleMap();
   }
 
   componentWillMount(): void {
@@ -164,15 +163,9 @@ export default class WysiwygEditor extends Component {
         newState.editorState = EditorState.createEmpty(this.compositeDecorator);
       }
     }
-    if (
-      props.editorState !== this.props.editorState ||
-      props.contentState !== this.props.contentState
-    ) {
-      extractInlineStyle(newState.editorState);
-    }
+
     this.setState(newState);
     this.editorProps = this.filterEditorProps(props);
-    this.customStyleMap = getCustomStyleMap();
   }
 
   onEditorBlur: Function = (): void => {


### PR DESCRIPTION
This is a perf fix for Edge/IE scenarios where lot of CPU time is consumed in extracting the inline styles from editor state in every re-render call.
Removing this line of code, had no change in how styles were rendered in the Editor.

This is for the issue - https://github.com/jpuri/react-draft-wysiwyg/issues/726
If this is really needed, let me know i have another solution which can be used.