### PR TITLE
Add default props to prop classnames so they don't evaluate as undefined

### DIFF
--- a/src/components/Dropdown/DropdownOption/index.js
+++ b/src/components/Dropdown/DropdownOption/index.js
@@ -23,6 +23,12 @@ export default class DropDownOption extends Component {
     title: PropTypes.string,
   };
 
+  static defaultProps = {
+    activeClassName: '',
+    disabledClassName: '',
+    highlightedClassName: ''
+  }
+
   onClick: Function = (event): void => {
     const { onSelect, onClick, value, disabled } = this.props;
     if (!disabled) {

--- a/src/components/Option/index.js
+++ b/src/components/Option/index.js
@@ -17,6 +17,10 @@ export default class Option extends Component {
     title: PropTypes.string,
   };
 
+  static defaultProps = {
+    activeClassName: '',
+  }
+
   onClick: Function = () => {
     const { disabled, onClick, value } = this.props;
     if (!disabled) {


### PR DESCRIPTION
Addresses #672 where dynamic classnames would evaluate an `undefined` prop. This adds a `defaultProps` to the components to ensure it will default to an empty string in the case that no class prop is passed.