### PR TITLE
Flex wrap options

### DIFF
--- a/src/controls/BlockType/Component/styles.css
+++ b/src/controls/BlockType/Component/styles.css
@@ -2,6 +2,7 @@
   display: flex;
   align-items: center;
   margin-bottom: 6px;
+  flex-wrap: wrap
 }
 .rdw-block-dropdown {
   width: 110px;

--- a/src/controls/ColorPicker/Component/styles.css
+++ b/src/controls/ColorPicker/Component/styles.css
@@ -3,6 +3,7 @@
   align-items: center;
   margin-bottom: 6px;
   position: relative;
+  flex-wrap: wrap
 }
 .rdw-colorpicker-modal {
   position: absolute;

--- a/src/controls/Embedded/Component/styles.css
+++ b/src/controls/Embedded/Component/styles.css
@@ -3,6 +3,7 @@
   align-items: center;
   margin-bottom: 6px;
   position: relative;
+  flex-wrap: wrap
 }
 .rdw-embedded-modal {
   position: absolute;

--- a/src/controls/Emoji/Component/styles.css
+++ b/src/controls/Emoji/Component/styles.css
@@ -3,6 +3,7 @@
   align-items: center;
   margin-bottom: 6px;
   position: relative;
+  flex-wrap: wrap
 }
 .rdw-emoji-modal {
   overflow: auto;

--- a/src/controls/FontFamily/Component/styles.css
+++ b/src/controls/FontFamily/Component/styles.css
@@ -2,6 +2,7 @@
   display: flex;
   align-items: center;
   margin-bottom: 6px;
+  flex-wrap: wrap
 }
 .rdw-fontfamily-dropdown {
   width: 115px;

--- a/src/controls/FontSize/Component/styles.css
+++ b/src/controls/FontSize/Component/styles.css
@@ -2,6 +2,7 @@
   display: flex;
   align-items: center;
   margin-bottom: 6px;
+  flex-wrap: wrap
 }
 .rdw-fontsize-dropdown {
   min-width: 40px;

--- a/src/controls/History/Component/styles.css
+++ b/src/controls/History/Component/styles.css
@@ -2,6 +2,7 @@
   display: flex;
   align-items: center;
   margin-bottom: 6px;
+  flex-wrap: wrap
 }
 .rdw-history-dropdownoption {
   height: 40px;

--- a/src/controls/Image/Component/styles.css
+++ b/src/controls/Image/Component/styles.css
@@ -3,6 +3,8 @@
   align-items: center;
   margin-bottom: 6px;
   position: relative;
+  flex-wrap: wrap
+
 }
 .rdw-image-modal {
   position: absolute;

--- a/src/controls/Image/Component/styles.css
+++ b/src/controls/Image/Component/styles.css
@@ -4,7 +4,6 @@
   margin-bottom: 6px;
   position: relative;
   flex-wrap: wrap
-
 }
 .rdw-image-modal {
   position: absolute;

--- a/src/controls/Inline/Component/styles.css
+++ b/src/controls/Inline/Component/styles.css
@@ -2,6 +2,8 @@
   display: flex;
   align-items: center;
   margin-bottom: 6px;
+  flex-wrap: wrap
+
 }
 .rdw-inline-dropdown {
   width: 50px;

--- a/src/controls/Inline/Component/styles.css
+++ b/src/controls/Inline/Component/styles.css
@@ -3,7 +3,6 @@
   align-items: center;
   margin-bottom: 6px;
   flex-wrap: wrap
-
 }
 .rdw-inline-dropdown {
   width: 50px;

--- a/src/controls/Link/Component/styles.css
+++ b/src/controls/Link/Component/styles.css
@@ -3,6 +3,7 @@
   align-items: center;
   margin-bottom: 6px;
   position: relative;
+  flex-wrap: wrap
 }
 .rdw-link-dropdown {
   width: 50px;

--- a/src/controls/List/Component/styles.css
+++ b/src/controls/List/Component/styles.css
@@ -2,6 +2,7 @@
   display: flex;
   align-items: center;
   margin-bottom: 6px;
+  flex-wrap: wrap
 }
 .rdw-list-dropdown {
   width: 50px;

--- a/src/controls/Remove/Component/styles.css
+++ b/src/controls/Remove/Component/styles.css
@@ -3,4 +3,5 @@
   align-items: center;
   margin-bottom: 6px;
   position: relative;
+  flex-wrap: wrap
 }

--- a/src/controls/TextAlign/Component/styles.css
+++ b/src/controls/TextAlign/Component/styles.css
@@ -2,6 +2,7 @@
   display: flex;
   align-items: center;
   margin-bottom: 6px;
+  flex-wrap: wrap
 }
 .rdw-text-align-dropdown {
   width: 50px;


### PR DESCRIPTION
Resizing to mobile sometimes let the options overflow,
with flex-wrap: wrap on the wrappers, the options will take a spot in a new row when there is no sufficient space in the current row

without flex-wrap:
![screen shot 2018-10-17 at 15 52 59](https://user-images.githubusercontent.com/22342373/47091285-e35d5380-d224-11e8-8649-ba35b3c4a51b.png)


with flex-wrap on wrappers:
![screen shot 2018-10-17 at 15 54 40](https://user-images.githubusercontent.com/22342373/47091343-ff60f500-d224-11e8-84d2-1aa81f68b125.png)

