### PR TITLE
ref.focusEditor() --> ref.focus() - Changed example to reflect correct draft-js function name

### DIFF
--- a/docs/src/components/Docs/Props/EditorRef/index.js
+++ b/docs/src/components/Docs/Props/EditorRef/index.js
@@ -12,7 +12,7 @@ export default () => (
       value={
         'const setEditorReference = (ref) => {\n' +
         '  this.editorReferece = ref;\n' +
-        '  ref.focusEditor();\n' +
+        '  ref.focus();\n' +
         '}\n' +
         '\n\n' +
         'const EditorWithRef = () => (\n' +


### PR DESCRIPTION
The [docs page](https://jpuri.github.io/react-draft-wysiwyg/#/docs) suggest `ref.focusEditor()` to focus - however the correct function name is `ref.focus()`

I've searched the docs and there is only this one reference to `focusEditor`.