### PR TITLE
Updated README to include draft-js in installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,10 @@ A Wysiwyg editor built using ReactJS and DraftJS libraries.
 ## Installing
 The package can be installed from npm `react-draft-wysiwyg`
 
+```
+$ npm install --save react-draft-wysiwyg draft-js
+```
+
 ## Getting started
 Editor can be used as simple React Component:
 ```js


### PR DESCRIPTION
This pull request handles issues that come up when a project doesn't already have draft-js installed. The documentation does not make clear that it must already be installed for react-draft-wysiwyg to work. I am hoping this PR will make this clear and eliminate the frustration of having it not work and possibly abandonment of react-draft-wysiwyg for another package (as I almost did when I ran into this issue).

**Issues**
- #390 
- #727 
- #700