### PR TITLE
Add export defaultToolbar for easier custom toolbar 

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -1,9 +1,9 @@
 /* @flow */
 
 import Editor from './Editor';
-import { defaultToolbar } from './config/defaultToolbar'
+import defaultToolbar from './config/defaultToolbar';
 
 module.exports = {
   Editor,
-  defaultToolbar
+  defaultToolbar,
 };

--- a/src/index.js
+++ b/src/index.js
@@ -1,7 +1,9 @@
 /* @flow */
 
 import Editor from './Editor';
+import { defaultToolbar } from './config/defaultToolbar'
 
 module.exports = {
   Editor,
+  defaultToolbar
 };


### PR DESCRIPTION
- add export defaultToolbar config json

### example 

if I want to add more fonts to toolbar

```javascript
import { defaultToolbar } from 'react-draft-wysiwyg'

const toolbar = {
  ...defaultToolbar,
  fontFamily: {
    options: ['Sukhumvit', 'CircularStd', ...defaultToolbar.fontFamily.options],
  }
}
```