### PR TITLE
update styles to handle alignment for multiline text

### DIFF
--- a/src/controls/TextAlign/Component/styles.css
+++ b/src/controls/TextAlign/Component/styles.css
@@ -14,15 +14,27 @@
   justify-content: center;
 }
 .rdw-right-aligned-block {
-  text-align: right;
+  text-align: right !important;
+}
+.rdw-right-aligned-block * {
+  text-align: right !important;
 }
 .rdw-left-aligned-block {
+  text-align: left !important;
+}
+.rdw-left-aligned-block * {
   text-align: left !important;
 }
 .rdw-center-aligned-block {
   text-align: center !important;
 }
+.rdw-center-aligned-block * {
+  text-align: center !important;
+}
 .rdw-justify-aligned-block {
+  text-align: justify !important;
+}
+.rdw-justify-aligned-block * {
   text-align: justify !important;
 }
 .rdw-right-aligned-block > div {


### PR DESCRIPTION
Saw this issue and implemented the suggested fix - https://github.com/jpuri/react-draft-wysiwyg/issues/751

I didn't see any contributing guidelines, so Let me know what I should do