### PR TITLE
Prevent the link modal from closing unexpectedly when the "Open link in a new window" label is clicked

### DIFF
--- a/src/controls/Link/Component/styles.css
+++ b/src/controls/Link/Component/styles.css
@@ -53,6 +53,7 @@
 }
 .rdw-link-modal-target-option > span {
   margin-left: 5px;
+  pointer-events: none;
 }
 .rdw-link-modal-btn {
   margin-left: 10px;


### PR DESCRIPTION
This weird issue appears in Chrome: if the editor has the `toolbarOnFocus` property enabled, and the user opens the link modal and immediately clicks the "Open link in a new window" label, the model unexpectedly closes.

Here is a short video when I reproduce this bug twice. On the third attempt I dodge the bug by focusing on one of the inputs prior to clicking the label:

![Kapture 2019-06-21 at 6 08 26](https://user-images.githubusercontent.com/1530865/59895016-8802e700-93eb-11e9-9f83-026bb5bfc301.gif)

This bug is caused by the label caption being wrapped into a `<span />`, which captures the `mousedown` event prior to its parent `<label />`, making the `src/Editor/index.js#preventDefault` function to fail.