### PR TITLE
[FIX] Fixes editor error Cannot read property 'editorState' of undefined at initial loading, when mention prop is used

### DIFF
--- a/src/Editor/index.js
+++ b/src/Editor/index.js
@@ -232,7 +232,7 @@ class WysiwygEditor extends Component {
 
   getWrapperRef = () => this.wrapper;
 
-  getEditorState = () => this.state.editorState;
+  getEditorState = () => this.state ? this.state.editorState : null;
 
   getSuggestions = () => this.props.mention && this.props.mention.suggestions;
 


### PR DESCRIPTION
When the mention prop is used, while mounting the editor, the library breaks the app sends this message: "Cannot read property editorState of undefined", this is fixed by evaluating if `this.state` is defined first at `getEditorState` in `src/Editor/index.js`

Based in @git9am response in issue https://github.com/jpuri/react-draft-wysiwyg/issues/922#issuecomment-594379081

Fixes: https://github.com/jpuri/react-draft-wysiwyg/issues/922

Solves this error:
```
TypeError: Cannot read property 'editorState' of undefined
a.getEditorState
node_modules/react-draft-wysiwyg/dist/react-draft-wysiwyg.js:7
```