### PR TITLE
Added active props on some toolbar option

### DIFF
--- a/src/controls/ColorPicker/Component/index.js
+++ b/src/controls/ColorPicker/Component/index.js
@@ -118,7 +118,7 @@ class LayoutComponent extends Component {
           title || translations['components.controls.colorpicker.colorpicker']
         }
       >
-        <Option onClick={onExpandEvent} className={classNames(className)}>
+        <Option onClick={onExpandEvent} className={classNames(className)} active={expanded}>
           <img src={icon} alt="" />
         </Option>
         {expanded ? this.renderModal() : undefined}

--- a/src/controls/Embedded/Component/index.js
+++ b/src/controls/Embedded/Component/index.js
@@ -142,6 +142,7 @@ class LayoutComponent extends Component {
           className={classNames(className)}
           value="unordered-list-item"
           onClick={onExpandEvent}
+          active={expanded}
           title={title || translations['components.controls.embedded.embedded']}
         >
           <img src={icon} alt="" />

--- a/src/controls/Emoji/Component/index.js
+++ b/src/controls/Emoji/Component/index.js
@@ -60,6 +60,7 @@ class LayoutComponent extends Component {
           className={classNames(className)}
           value="unordered-list-item"
           onClick={onExpandEvent}
+          active={expanded}
         >
           <img
             src={icon}

--- a/src/controls/Image/Component/index.js
+++ b/src/controls/Image/Component/index.js
@@ -347,6 +347,7 @@ class LayoutComponent extends Component {
           className={classNames(className)}
           value="unordered-list-item"
           onClick={onExpandEvent}
+          active={expanded}
           title={title || translations['components.controls.image.image']}
         >
           <img src={icon} alt="" />

--- a/src/controls/Link/Component/index.js
+++ b/src/controls/Link/Component/index.js
@@ -182,6 +182,7 @@ class LayoutComponent extends Component {
             onClick={this.signalExpandShowModal}
             aria-haspopup="true"
             aria-expanded={showModal}
+            active={expanded && showModal}
             title={link.title || translations['components.controls.link.link']}
           >
             <img src={link.icon} alt="" />


### PR DESCRIPTION
added active props on these toolbar options:
 "color picker, embedded, emoji, image, link"

So when those toolbar is clicked, the style will be changed to be border inset like the other common (bold, italic, underlined) toolbar options 