### PR TITLE
Add `globalObject: 'this'` option to webpack config

### DIFF
--- a/config/webpack.config.js
+++ b/config/webpack.config.js
@@ -13,6 +13,7 @@ module.exports = {
     filename: 'react-draft-wysiwyg.js',
     library: 'reactDraftWysiwyg',
     libraryTarget: 'umd',
+    globalObject: 'this',
   },
   externals: {
     react: 'react',


### PR DESCRIPTION
This PR fixes an error `typeof window is not defined` in node env.

It fixes #920 and #893 

UMD module spec has `root` object.

Both node and browser have respective own root, `global`, `window`. And we can access their root by `this` in global execution context.

So, this pr sets root object to `this` not `window`.

FYI: https://github.com/webpack/webpack/issues/6642#issuecomment-371087342