### PR TITLE
Fix to focus editor when null

### DIFF
--- a/src/Editor/__test__/editorTest.js
+++ b/src/Editor/__test__/editorTest.js
@@ -14,7 +14,7 @@ describe("Editor test suite", () => {
     ).to.equal("div");
   });
 
-  xit("should have an editorState object in state", () => {
+  it("should have an editorState object in state", () => {
     const editor = shallow(<Editor />);
     assert.isDefined(editor.state().editorState);
     assert.isDefined(editor.state().editorFocused);
@@ -24,4 +24,12 @@ describe("Editor test suite", () => {
     const editor = shallow(<Editor />);
     expect(editor.find(".rdw-editor-toolbar")).to.have.length(1);
   });
+
+  it("should not focus editor when toggle to a second editor", () => {
+    const firstEditor = shallow(<Editor />);
+    const secondEditor = shallow(<Editor />);
+    secondEditor.childAt(1).simulate('click');
+    assert.isDefined(firstEditor.state().editorFocused);
+    assert.isDefined(secondEditor.state().editorFocused);
+  })
 });

--- a/src/Editor/index.js
+++ b/src/Editor/index.js
@@ -347,7 +347,9 @@ class WysiwygEditor extends Component {
 
   focusEditor = () => {
     setTimeout(() => {
-      this.editor.focus();
+      if(this.editor){
+        this.editor.focus();
+      }
     });
   };
 


### PR DESCRIPTION
Steps to reproduce. 

1. Create two components with react-draft-wysiwyg one in `readOnly` mode and the other in `editing` mode.

2. If the `readOnly` mode component is clicked the `editing` component is rendered instead of the `readOnly`.

3. Since the `readOnly` component was removed from DOM this error will appear on the console. 

![image](https://user-images.githubusercontent.com/42775600/85411829-7a1c0080-b52e-11ea-8463-8f32abbccc7f.png)

The problem is solved when the `focusEditor` function is wrapped with an `if` statement in order to verify if the `Editor` still exists.

This fix also works for the test that was commented as pending and the #712 issue.

@jpuri  We'll love to contribute to this library, let us know if something is missing or  can be improved. 