### PR TITLE
Changed center image alignment

### DIFF
--- a/src/renderer/Image/index.js
+++ b/src/renderer/Image/index.js
@@ -24,7 +24,7 @@ const getImageComponent = config => class Image extends Component {
   };
 
   setEntityAlignmentCenter: Function = (): void => {
-    this.setEntityAlignment('none');
+    this.setEntityAlignment('center');
   };
 
   setEntityAlignment: Function = (alignment): void => {
@@ -95,7 +95,7 @@ const getImageComponent = config => class Image extends Component {
           {
             'rdw-image-left': alignment === 'left',
             'rdw-image-right': alignment === 'right',
-            'rdw-image-center': !alignment || alignment === 'none',
+            'rdw-image-center': !alignment || alignment === 'center',
           },
         )}
       >


### PR DESCRIPTION
When aligning an image to the center, the alignment is set to `'none'` instead of `'center'`. As a result centered images don't work when using [draftjs-to-html](https://github.com/jpuri/draftjs-to-html). 