### PR TITLE
Relative imports outside of src/ are not supported

### DIFF
--- a/docs/src/components/Docs/Usage/index.js
+++ b/docs/src/components/Docs/Usage/index.js
@@ -17,7 +17,7 @@ const Usage = () => (
       value={
         'import React, { Component } from \'react\';\n' +
         'import { Editor } from \'react-draft-wysiwyg\';\n' +
-        'import \'../node_modules/react-draft-wysiwyg/dist/react-draft-wysiwyg.css\';\n' +
+        'import \'react-draft-wysiwyg/dist/react-draft-wysiwyg.css\';\n' +
         '\n\n' +
         'const EditorComponent = () => <Editor />'
       }


### PR DESCRIPTION
There are instances where react gives  `Relative imports outside of src/ are not supported` error  when trying to import resources outside of the src folder.
Just to be save let's just take out  the  `../node_modules/` part.