### PR TITLE
Fix: editorReferece -> editorReference typo fix

### DIFF
--- a/docs/src/components/Docs/Props/EditorRef/index.js
+++ b/docs/src/components/Docs/Props/EditorRef/index.js
@@ -11,7 +11,7 @@ export default () => (
     <Codemirror
       value={
         'const setEditorReference = (ref) => {\n' +
-        '  this.editorReferece = ref;\n' +
+        '  this.editorReference = ref;\n' +
         '  ref.focus();\n' +
         '}\n' +
         '\n\n' +


### PR DESCRIPTION
Fixes a typo that caught me out in the docs.

editorReferece -> editorReference