### PR TITLE
Enabling toolbar styling

### DIFF
--- a/src/Editor/index.js
+++ b/src/Editor/index.js
@@ -447,7 +447,7 @@ class WysiwygEditor extends Component {
       >
         {!toolbarHidden && (
           <div
-            className={classNames('rdw-editor-toolbar', toolbarClassName)}
+            className={classNames(toolbarClassName, 'rdw-editor-toolbar')}
             style={{
               visibility: toolbarShow ? 'visible' : 'hidden',
               ...toolbarStyle,


### PR DESCRIPTION
the rdw-editor-toolbar styles overrides any customization of the toolbar, unlike wrapper and editor do.
The toolbar's classNames order should be reversed.