### PR TITLE
fix toolbar not displaying currentFontSize

### DIFF
--- a/src/controls/FontSize/__test__/fontSizeControlTest.js
+++ b/src/controls/FontSize/__test__/fontSizeControlTest.js
@@ -5,18 +5,19 @@ import { expect, assert } from 'chai';
 import { mount } from 'enzyme';
 import {
   EditorState,
-  convertFromHTML,
   ContentState,
 } from 'draft-js';
+import htmlToDraft from "html-to-draftjs";
 import FontSizeControl from '..';
+import FontSizeComponent from '../Component';
 import { Dropdown } from '../../../components/Dropdown';
 import defaultToolbar from '../../../config/defaultToolbar';
 import ModalHandler from '../../../event-handler/modals';
 import localeTranslations from '../../../i18n';
 
 describe('FontSizeControl test suite', () => {
-  const contentBlocks = convertFromHTML('<div>test</div>');
-  const contentState = ContentState.createFromBlockArray(contentBlocks);
+  const { contentBlocks, entityMap } = htmlToDraft('<div style="font-size:20px">test</div>');
+  const contentState = ContentState.createFromBlockArray(contentBlocks, entityMap);
   const editorState = EditorState.createWithContent(contentState);
 
   it('should have a div when rendered', () => {
@@ -44,5 +45,18 @@ describe('FontSizeControl test suite', () => {
     assert.equal(control.find(Dropdown).length, 1);    
     assert.equal(control.find(Dropdown).prop('children').length, 2);
     assert.isDefined(control.childAt(0).props().onChange);
+  });
+
+  it('it passes correct currentState.fontSize prop down to FontSizeComponent', () => {
+    const control = mount(
+      <FontSizeControl
+        onChange={() => {}}
+        editorState={editorState}
+        config={defaultToolbar.fontSize}
+        translations={localeTranslations.en}
+        modalHandler={new ModalHandler()}
+      />,
+    );
+    assert.equal(control.find(FontSizeComponent).prop('currentState').fontSize, 20);
   });
 });

--- a/src/controls/FontSize/index.js
+++ b/src/controls/FontSize/index.js
@@ -79,7 +79,10 @@ export default class FontSize extends Component {
     const { config, translations } = this.props;
     const { expanded, currentFontSize } = this.state;
     const FontSizeComponent = config.component || LayoutComponent;
-    const fontSize = currentFontSize && Number(currentFontSize.substring(9));
+    let fontSize;
+    if (/\d+/.test(currentFontSize)) {
+      fontSize = Number(currentFontSize.match(/\d+/)[0]);
+    }
     return (
       <FontSizeComponent
         config={config}


### PR DESCRIPTION
It fixes this issue https://github.com/jpuri/react-draft-wysiwyg/issues/972.