### PR TITLE
readme file update for next.js

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,28 @@ import "react-draft-wysiwyg/dist/react-draft-wysiwyg.css";
 />;
 ```
 
+
+###  [Next.js](https://nextjs.org/)
+
+To use react-draft-wysiwyg with Next.js, please use the dynamic import syntax like below:
+
+```javascript
+import dynamic from "next/dynamic";
+import "react-draft-wysiwyg/dist/react-draft-wysiwyg.css"; 
+
+const Editor = dynamic( () => import("react-draft-wysiwyg").then((module) => module.Editor),{
+  ssr: false 
+});
+
+<Editor
+  editorState={editorState}
+  toolbarClassName="toolbarClassName"
+  wrapperClassName="wrapperClassName"
+  editorClassName="editorClassName"
+  onEditorStateChange={this.onEditorStateChange}
+/>;
+```
+
 ## Docs
 
 For more documentation check [here](https://jpuri.github.io/react-draft-wysiwyg/#/docs?_k=jjqinp).


### PR DESCRIPTION
I was unable to add react-draft-wysiwyg with my next.js project. After searching for 2days I found a solution and more people are also struggling with that. I have come out with a solution so that it works fine with next.js if add this to the doc it will be a good solution.

The working link of this is here: [codesandbox](https://codesandbox.io/s/react-draft-wysiwyg-tcj10?file=/components/TextEditor.js:286-400) 

Please approve and help people to make it use a better way. 