### PR TITLE
Allow Linkify to be Optional

### DIFF
--- a/package.json
+++ b/package.json
@@ -91,7 +91,8 @@
     "flow": "flow; test $? -eq 0 -o $? -eq 2",
     "check": "npm run lint && npm run flow",
     "storybook": "storybook dev -p 6006",
-    "build-storybook": "storybook build"
+    "build-storybook": "storybook build",
+    "prepare": "npm run build"
   },
   "license": "MIT",
   "eslintConfig": {

--- a/src/config/defaultToolbar.js
+++ b/src/config/defaultToolbar.js
@@ -181,7 +181,8 @@ export default {
     options: ["link", "unlink"],
     link: { icon: link, className: undefined, title: undefined },
     unlink: { icon: unlink, className: undefined, title: undefined },
-    linkCallback: undefined
+    linkCallback: undefined,
+    linkify: true
   },
   emoji: {
     icon: emoji,

--- a/src/controls/Link/index.js
+++ b/src/controls/Link/index.js
@@ -62,9 +62,13 @@ class Link extends Component {
     } = this.props;
 
     if (action === 'link') {
-      const linkifyCallback = linkCallback || linkifyLink;
-      const linkified = linkifyCallback({ title, target, targetOption });
-      this.addLink(linkified.title, linkified.target, linkified.targetOption);
+      if (linkify) {
+        const linkifyCallback = linkCallback || linkifyLink;
+        const linkified = linkifyCallback({ title, target, targetOption });
+        this.addLink(linkified.title, linkified.target, linkified.targetOption);
+      } else {
+        this.addLink(title, target, targetOption);
+      }
     } else {
       this.removeLink();
     }


### PR DESCRIPTION
Linkify has a configuration that might not be optimal in all situations. Being able to optionally bypass Linkify is useful in our situation and maybe to others.

The default is `true` so the library continues to work as-is.
