### PR TITLE
bug: aria-expanded and aria-haspopup for Link control

### DIFF
--- a/src/controls/Link/Component/index.js
+++ b/src/controls/Link/Component/index.js
@@ -174,14 +174,14 @@ class LayoutComponent extends Component {
       <div
         className={classNames('rdw-link-wrapper', className)}
         aria-label="rdw-link-control"
+        aria-haspopup="true"
+        aria-expanded={showModal}
       >
         {options.indexOf('link') >= 0 && (
           <Option
             value="unordered-list-item"
             className={classNames(link.className)}
             onClick={this.signalExpandShowModal}
-            aria-haspopup="true"
-            aria-expanded={showModal}
             title={link.title || translations['components.controls.link.link']}
           >
             <img src={link.icon} alt="" />


### PR DESCRIPTION
https://github.com/jpuri/react-draft-wysiwyg/issues/704 
Attributes were present on wrong place on`<Option` component props level
Moving on parent level instead of Option component