### PR TITLE
fix link to EditorState in draftJS docs

### DIFF
--- a/docs/src/components/Docs/Props/EditorStateProp/index.js
+++ b/docs/src/components/Docs/Props/EditorStateProp/index.js
@@ -4,7 +4,7 @@ import Codemirror from 'react-codemirror';
 export const EditorStateLink = () => <a
     target="_blank"
     rel="noopener noreferrer"
-    href="https://facebook.github.io/draft-js/docs/api-reference-editor-state.html#content"
+    href="https://facebook.github.io/draft-js/docs/api-reference-editor-state#content"
   >
     EditorState
   </a>;


### PR DESCRIPTION
The old link https://facebook.github.io/draft-js/docs/api-reference-editor-state.html#content is broken. Replaced it with https://facebook.github.io/draft-js/docs/api-reference-editor-state#content

The broken link is visible at https://jpuri.github.io/react-draft-wysiwyg/#/docs , it's the first hyperlink after "Editor state"