### PR TITLE
Add ability to validate Link and Embedded url

### DIFF
--- a/docs/src/components/Docs/Props/CustomizingToolbarProp/defaultToolbar.js
+++ b/docs/src/components/Docs/Props/CustomizingToolbarProp/defaultToolbar.js
@@ -104,6 +104,7 @@ export default "{\n" +
   "    component: undefined,\n" +
   "    popupClassName: undefined,\n" +
   "    embedCallback: undefined,\n" +
+  "    embedValidator: undefined,\n" +
   "    defaultSize: {\n" +
   "      height: 'auto',\n" +
   "      width: 'auto',\n" +

--- a/docs/src/components/Docs/Props/CustomizingToolbarProp/index.js
+++ b/docs/src/components/Docs/Props/CustomizingToolbarProp/index.js
@@ -160,6 +160,14 @@ export default () => (
         </span>
       </li>
       <li>
+        <b>link: linkValidator</b>
+        <span>
+          : This is a function validate the link added by the user. 
+          The validator is passed the link text input by the user and is 
+          expected to return a boolean.
+        </span>
+      </li>
+      <li>
         <b>emoji: emojis</b>
         <span>
           : The property is arrary of emoji characters (unicodes). Which are

--- a/docs/src/components/Docs/Props/CustomizingToolbarProp/index.js
+++ b/docs/src/components/Docs/Props/CustomizingToolbarProp/index.js
@@ -190,6 +190,13 @@ export default () => (
         </span>
       </li>
       <li>
+        <b>embedded: embedValidator</b>
+        <span>
+          : This is a function validate the url added by the user. The validator
+          is passed the url input by the user and is expected to return a boolean.
+        </span>
+      </li>
+      <li>
         <b>image: urlEnabled</b>
         <span>
           : The property can be used to configure if the option to specify image

--- a/src/config/defaultToolbar.js
+++ b/src/config/defaultToolbar.js
@@ -181,7 +181,8 @@ export default {
     options: ["link", "unlink"],
     link: { icon: link, className: undefined, title: undefined },
     unlink: { icon: unlink, className: undefined, title: undefined },
-    linkCallback: undefined
+    linkCallback: undefined,
+    linkValidator: undefined
   },
   emoji: {
     icon: emoji,

--- a/src/config/defaultToolbar.js
+++ b/src/config/defaultToolbar.js
@@ -328,6 +328,7 @@ export default {
     component: undefined,
     popupClassName: undefined,
     embedCallback: undefined,
+    embedValidator: undefined,
     defaultSize: {
       height: "auto",
       width: "auto"

--- a/src/controls/Embedded/Component/index.js
+++ b/src/controls/Embedded/Component/index.js
@@ -20,6 +20,9 @@ class LayoutComponent extends Component {
     embeddedLink: '',
     height: this.props.config.defaultSize.height,
     width: this.props.config.defaultSize.width,
+    embeddedLinkValid: false,
+    heightValid: !!this.props.config.defaultSize.height,
+    widthValid: !!this.props.config.defaultSize.width,
   };
 
   componentDidUpdate(prevProps) {
@@ -30,24 +33,55 @@ class LayoutComponent extends Component {
         embeddedLink: '',
         height,
         width,
+        embeddedLinkValid: false,
+        heightValid: !!height,
+        widthValid: !!width,
       });
     }
   }
 
+  validateValue = (name, value) => {
+    if (name === 'embeddedLink') {
+      const { embedValidator } = this.props.config;
+      return !!value && (!embedValidator ? true : embedValidator(value));
+    }
+    return !!value;
+  }
+
+  isValid = () => {
+    const {
+      embeddedLinkValid,
+      heightValid,
+      widthValid,
+    } = this.state;
+    return embeddedLinkValid && heightValid && widthValid;
+  }
+
   onChange = () => {
+    if (!this.isValid()) return;
     const { onChange } = this.props;
     const { embeddedLink, height, width } = this.state;
     onChange(embeddedLink, height, width);
   };
 
   updateValue = event => {
+    const { name, value } = event.target;
     this.setState({
-      [`${event.target.name}`]: event.target.value,
+      [`${name}`]: value,
+      [`${name}Valid`]: this.validateValue(name, value),
     });
   };
 
   rendeEmbeddedLinkModal() {
-    const { embeddedLink, height, width } = this.state;
+    const {
+      embeddedLink,
+      height,
+      width,
+      embeddedLinkValid,
+      heightValid,
+      widthValid,
+    } = this.state;
+    console.log('heightValid', heightValid);
     const {
       config: { popupClassName },
       doCollapse,
@@ -67,7 +101,11 @@ class LayoutComponent extends Component {
         <div className="rdw-embedded-modal-link-section">
           <span className="rdw-embedded-modal-link-input-wrapper">
             <input
-              className="rdw-embedded-modal-link-input"
+              className={classNames({
+                'rdw-embedded-modal-link-input': true,
+                valid: embeddedLinkValid,
+                invalid: !embeddedLinkValid,
+              })}
               placeholder={
                 translations['components.controls.embedded.enterlink']
               }
@@ -85,7 +123,11 @@ class LayoutComponent extends Component {
                 onBlur={this.updateValue}
                 value={height}
                 name="height"
-                className="rdw-embedded-modal-size-input"
+                className={classNames({
+                  'rdw-embedded-modal-size-input': true,
+                  valid: heightValid,
+                  invalid: !heightValid,
+                })}
                 placeholder="Height"
               />
               <span className="rdw-image-mandatory-sign">*</span>
@@ -96,7 +138,11 @@ class LayoutComponent extends Component {
                 onBlur={this.updateValue}
                 value={width}
                 name="width"
-                className="rdw-embedded-modal-size-input"
+                className={classNames({
+                  'rdw-embedded-modal-size-input': true,
+                  valid: widthValid,
+                  invalid: !widthValid,
+                })}
                 placeholder="Width"
               />
               <span className="rdw-image-mandatory-sign">*</span>
@@ -108,7 +154,7 @@ class LayoutComponent extends Component {
             type="button"
             className="rdw-embedded-modal-btn"
             onClick={this.onChange}
-            disabled={!embeddedLink || !height || !width}
+            disabled={!this.isValid()}
           >
             {translations['generic.add']}
           </button>

--- a/src/controls/Embedded/Component/styles.css
+++ b/src/controls/Embedded/Component/styles.css
@@ -53,6 +53,10 @@
   font-size: 15px;
   padding: 0 5px;
 }
+.rdw-embedded-modal-link-input.invalid {
+  border: 1px solid #ffadad;
+  background: #fffafa;
+}
 .rdw-embedded-modal-link-input-wrapper {
   display: flex;
   align-items: center;
@@ -98,6 +102,10 @@
   border: 1px solid #F1F1F1;
   border-radius: 2px;
   font-size: 12px;
+}
+.rdw-embedded-modal-size-input.invalid {
+  border: 1px solid #ffadad;
+  background: #fffafa;
 }
 .rdw-embedded-modal-size-input:focus {
   outline: none;

--- a/src/controls/Link/Component/styles.css
+++ b/src/controls/Link/Component/styles.css
@@ -45,6 +45,10 @@
 .rdw-link-modal-input:focus {
   outline: none;
 }
+.rdw-link-modal-input.invalid {
+  border: 1px solid #ffadad;
+  background: #fffafa;
+}
 .rdw-link-modal-buttonsection {
   margin: 0 auto;
 }

--- a/src/controls/Link/__test__/linkControlTest.js
+++ b/src/controls/Link/__test__/linkControlTest.js
@@ -113,6 +113,23 @@ describe("LinkControl test suite", () => {
     );
   });
 
+  it("should use custom validator if one is set with linkValidator", () => {
+    const onChange = spy();
+    const control = mount(<LinkControl config={{ ...defaultToolbar.link, linkValidator: target => false }} onChange={onChange} editorState={editorState} translations={localeTranslations.en} modalHandler={new ModalHandler()} />);
+    control.setState({ expanded: true });
+    const buttons = control.find(".rdw-option-wrapper");
+    buttons.first().simulate("click");
+    const inputs = control.find(".rdw-link-modal-input");
+    inputs.last().simulate("change", {
+      target: { name: "linkTitle", value: "the google" }
+    });
+    inputs.first().simulate("change", {
+      target: { name: "linkTarget", value: "www.google.com" }
+    });
+    const addButton = control.find(".rdw-link-modal-btn").first();
+    assert.isTrue(addButton.prop('disabled'));
+  });
+
   it("should return input value by default", () => {
     const onChange = spy();
     const control = mount(


### PR DESCRIPTION
Thanks for providing a great library @jpuri 

I needed the ability to validate the links so I have created this PR to add config options to validate the urls input for Link and Embedded

- Add `linkValidator` config options to provide functions to validate Link target
- Adds valid/invalid classes to Link modal title and target
- Disable Add Link button when not target valid  
- Add `embedValidator` config options to provide functions to validate Embedded url
- Adds valid/invalid classes to Embedded modal link, width and height
- Disable Add Embedded button when link not valid 

This is partly based on #355, however it does not provide "allowRelative" link functionality nor prepends links with 'https://'. Both should be possible with a combination of the new `linkValidator` and the existing `linkCallback`

Possibly related to #483