### PR TITLE
[Issue-1429] Resolve Bug for Mention Suggestion Clicks Overwriting Text

### DIFF
--- a/src/decorators/Mention/Suggestion/index.js
+++ b/src/decorators/Mention/Suggestion/index.js
@@ -222,20 +222,22 @@ function getSuggestionComponent() {
         });
     };
 
-    addMention = () => {
+    addMention = (mentionIndexOnClick) => {
       const { activeOption } = this.state;
       const editorState = config.getEditorState();
-      const { onChange, separator, trigger } = config;
+      const { onChange, trigger } = config;
       const selectedMention = this.filteredSuggestions[activeOption];
+      const mentionIndex = mentionIndexOnClick ?? editorState.getSelection().focusOffset - 1;
       if (selectedMention) {
-        addMention(editorState, onChange, separator, trigger, selectedMention);
+        addMention(editorState, onChange, trigger, selectedMention, mentionIndex);
       }
     };
 
     render() {
       const { children } = this.props;
       const { activeOption, showSuggestions } = this.state;
-      const { dropdownClassName, optionClassName } = config;
+      const { dropdownClassName, getEditorState, optionClassName } = config;
+      const mentionIndex = getEditorState().getSelection().focusOffset - 1;
       return (
         <span
           className="rdw-suggestion-wrapper"
@@ -260,7 +262,7 @@ function getSuggestionComponent() {
                 <span
                   key={index}
                   spellCheck={false}
-                  onClick={this.addMention}
+                  onClick={() => this.addMention(mentionIndex)}
                   data-index={index}
                   onMouseEnter={this.onOptionMouseEnter}
                   onMouseLeave={this.onOptionMouseLeave}

--- a/src/decorators/Mention/addMention.js
+++ b/src/decorators/Mention/addMention.js
@@ -7,9 +7,9 @@ import { getSelectedBlock } from 'draftjs-utils';
 export default function addMention(
   editorState: EditorState,
   onChange: Function,
-  separator: string,
   trigger: string,
   suggestion: Object,
+  mentionIndex: number
 ): void {
   const { value, url } = suggestion;
   const entityKey = editorState
@@ -18,12 +18,8 @@ export default function addMention(
     .getLastCreatedEntityKey();
   const selectedBlock = getSelectedBlock(editorState);
   const selectedBlockText = selectedBlock.getText();
-  let focusOffset = editorState.getSelection().focusOffset;
-  const mentionIndex = (selectedBlockText.lastIndexOf(separator + trigger, focusOffset) || 0) + 1;
+  const focusOffset = mentionIndex + 1
   let spaceAlreadyPresent = false;
-  if (selectedBlockText.length === mentionIndex + 1) {
-    focusOffset = selectedBlockText.length;
-  }
   if (selectedBlockText[focusOffset] === ' ') {
     spaceAlreadyPresent = true;
   }


### PR DESCRIPTION
Resolved the following issue: https://github.com/jpuri/react-draft-wysiwyg/issues/1429.

Root Cause: Clicks on the suggestion dropdown menu forcibly change the `anchorOffset` and `focusOffset` position of the cursor. 

Resolved by:
- Establishing the `mentionIndex` prior to the click taking place, and passing it into the `addMention` function.

This was the optimal quick solution for now since stopping click event propagation or preventing default click behavior did not prevent the cursor position from updating.

Any expediency with reviewing and merging this bug fix would be appreciated, @jpuri.